### PR TITLE
Mention library-repos-install scripts in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ kicad-library
 
 The schematic and 3D libraries supported by KiCad team.
 
-The footprint libraries are the `\*.pretty` repos themselves. If you want to
+The footprint libraries are the `*.pretty` repos themselves. If you want to
 download the libraries locally, the `library-repos-install.bat` and
 `library-repos-install.sh` scripts [in the KiCad source](http://bazaar.launchpad.net/~kicad-product-committers/kicad/product/files/head:/scripts/)
 can do this automatically.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 kicad-library
 =============
 
-The schematic and 3D libraries supported by KiCad team.  Note that the footprint libraries are the *.pretty repos themselves.
+The schematic and 3D libraries supported by KiCad team.
+
+The footprint libraries are the `\*.pretty` repos themselves. If you want to
+download the libraries locally, the `library-repos-install.bat` and
+`library-repos-install.sh` scripts [in the KiCad source](http://bazaar.launchpad.net/~kicad-product-committers/kicad/product/files/head:/scripts/)
+can do this automatically.


### PR DESCRIPTION
I thought it'd be a good idea to mention how to download the PCB footprint libraries locally in the README here, since we point them to the repos themselves as well.