### PR TITLE
Add DC Power Jack to DC Barrel Jack component

### DIFF
--- a/library/conn.dcm
+++ b/library/conn.dcm
@@ -2,6 +2,7 @@ EESchema-DOCLIB  Version 2.0
 #
 $CMP BARREL_JACK
 D DC Barrel Jack
+K DC power barrel jack connector
 $ENDCMP
 #
 $CMP BUSAT


### PR DESCRIPTION
Add also the word 'power', otherwise you won't find the component searching on: "DC Power Jack". Which is too bad.