### PR TITLE
Fix APPDATA environment variablt syntax for cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ if( UNIX )
             CACHE PATH "Location of user specifig KiCad config files" )
     endif()
 elseif( MINGW )
-    set( KICAD_USER_CONFIG_DIR $ENV{%APPDATA%}/kicad
+    set( KICAD_USER_CONFIG_DIR $ENV{APPDATA}/kicad
         CACHE PATH "Location of user specifig KiCad config files" )
 endif()
 


### PR DESCRIPTION
The environment variable syntax used in the CMakeLists.txt can error like:
```
Make Warning (dev) at CMakeLists.txt:37 (set):
  Policy CMP0053 is not set: Simplify variable reference and escape sequence
  evaluation.  Run "cmake --help-policy CMP0053" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

  For input:

    '$ENV{%APPDATA%}/kicad'

  the old evaluation rules produce:

    '/kicad'

  but the new evaluation rules produce an error:

    Syntax error in cmake code at
      C:/Jenkins/workspace/windows-kicad-msys2-nightlies/msys64/home/SYSTEM/MINGW-packages/mingw-w64-kicad-git/src/kicad-libs/CMakeLists.txt:37
    when parsing string
      $ENV{%APPDATA%}/kicad
    Invalid character ('%') in a variable name: ''

  Using the old result for compatibility since the policy is not set.

This warning is for project developers.  Use -Wno-dev to suppress it.
```