### PR TITLE
Fixed misspells for Schottky diodes.

### DIFF
--- a/library/device.dcm
+++ b/library/device.dcm
@@ -62,62 +62,62 @@ D Diode Schottky
 $ENDCMP
 #
 $CMP D_Schottky_x2_ACom_AKK
-D Double diode Shottky (Serie)
+D Double diode Schottky (Serie)
 K DEV DIODE
 $ENDCMP
 #
 $CMP D_Schottky_x2_ACom_KAK
-D Double diode Shottky (Serie)
+D Double diode Schottky (Serie)
 K DEV DIODE
 $ENDCMP
 #
 $CMP D_Schottky_x2_ACom_KKA
-D Double diode Shottky (Serie)
+D Double diode Schottky (Serie)
 K DEV DIODE
 $ENDCMP
 #
 $CMP D_Schottky_x2_KCom_AAK
-D Double diode Shottky (Serie)
+D Double diode Schottky (Serie)
 K DEV DIODE
 $ENDCMP
 #
 $CMP D_Schottky_x2_KCom_AKA
-D Double diode Shottky (Serie)
+D Double diode Schottky (Serie)
 K DEV DIODE
 $ENDCMP
 #
 $CMP D_Schottky_x2_KCom_KAA
-D Double diode Shottky (Serie)
+D Double diode Schottky (Serie)
 K DEV DIODE
 $ENDCMP
 #
 $CMP D_Schottky_x2_Serial_ACK
-D Double diode Shottky (Serie)
+D Double diode Schottky (Serie)
 K DEV DIODE
 $ENDCMP
 #
 $CMP D_Schottky_x2_Serial_AKC
-D Double diode Shottky (Serie)
+D Double diode Schottky (Serie)
 K DEV DIODE
 $ENDCMP
 #
 $CMP D_Schottky_x2_Serial_CAK
-D Double diode Shottky (Serie)
+D Double diode Schottky (Serie)
 K DEV DIODE
 $ENDCMP
 #
 $CMP D_Schottky_x2_Serial_CKA
-D Double diode Shottky (Serie)
+D Double diode Schottky (Serie)
 K DEV DIODE
 $ENDCMP
 #
 $CMP D_Schottky_x2_Serial_KAC
-D Double diode Shottky (Serie)
+D Double diode Schottky (Serie)
 K DEV DIODE
 $ENDCMP
 #
 $CMP D_Schottky_x2_Serial_KCA
-D Double diode Shottky (Serie)
+D Double diode Schottky (Serie)
 K DEV DIODE
 $ENDCMP
 #


### PR DESCRIPTION
I found misspells on the Schottly diode descrioption lines and fixed them. Glad to be pulled this request.

Thank you.
