### PR TITLE
Added descriptions for the CONN_AAxBB connectors in conn.dcm

### DIFF
--- a/library/conn.dcm
+++ b/library/conn.dcm
@@ -40,6 +40,326 @@ D Symbole general de connexion
 K CONN
 $ENDCMP
 #
+$CMP CONN_01X01
+D Connector 01x01
+$ENDCMP
+#
+$CMP CONN_01X02
+D Connector 01x02
+$ENDCMP
+#
+$CMP CONN_01X03
+D Connector 01x03
+$ENDCMP
+#
+$CMP CONN_01X04
+D Connector 01x04
+$ENDCMP
+#
+$CMP CONN_01X05
+D Connector 01x05
+$ENDCMP
+#
+$CMP CONN_01X06
+D Connector 01x06
+$ENDCMP
+#
+$CMP CONN_01X07
+D Connector 01x07
+$ENDCMP
+#
+$CMP CONN_01X08
+D Connector 01x08
+$ENDCMP
+#
+$CMP CONN_01X09
+D Connector 01x09
+$ENDCMP
+#
+$CMP CONN_01X10
+D Connector 01x10
+$ENDCMP
+#
+$CMP CONN_01X11
+D Connector 01x11
+$ENDCMP
+#
+$CMP CONN_01X12
+D Connector 01x12
+$ENDCMP
+#
+$CMP CONN_01X13
+D Connector 01x13
+$ENDCMP
+#
+$CMP CONN_01X14
+D Connector 01x14
+$ENDCMP
+#
+$CMP CONN_01X15
+D Connector 01x15
+$ENDCMP
+#
+$CMP CONN_01X16
+D Connector 01x16
+$ENDCMP
+#
+$CMP CONN_01X17
+D Connector 01x17
+$ENDCMP
+#
+$CMP CONN_01X18
+D Connector 01x18
+$ENDCMP
+#
+$CMP CONN_01X19
+D Connector 01x19
+$ENDCMP
+#
+$CMP CONN_01X20
+D Connector 01x20
+$ENDCMP
+#
+$CMP CONN_01X21
+D Connector 01x21
+$ENDCMP
+#
+$CMP CONN_01X22
+D Connector 01x22
+$ENDCMP
+#
+$CMP CONN_01X23
+D Connector 01x23
+$ENDCMP
+#
+$CMP CONN_01X24
+D Connector 01x24
+$ENDCMP
+#
+$CMP CONN_01X25
+D Connector 01x25
+$ENDCMP
+#
+$CMP CONN_01X26
+D Connector 01x26
+$ENDCMP
+#
+$CMP CONN_01X27
+D Connector 01x27
+$ENDCMP
+#
+$CMP CONN_01X28
+D Connector 01x28
+$ENDCMP
+#
+$CMP CONN_01X29
+D Connector 01x29
+$ENDCMP
+#
+$CMP CONN_01X30
+D Connector 01x30
+$ENDCMP
+#
+$CMP CONN_01X31
+D Connector 01x31
+$ENDCMP
+#
+$CMP CONN_01X32
+D Connector 01x32
+$ENDCMP
+#
+$CMP CONN_01X33
+D Connector 01x33
+$ENDCMP
+#
+$CMP CONN_01X34
+D Connector 01x34
+$ENDCMP
+#
+$CMP CONN_01X35
+D Connector 01x35
+$ENDCMP
+#
+$CMP CONN_01X36
+D Connector 01x36
+$ENDCMP
+#
+$CMP CONN_01X37
+D Connector 01x37
+$ENDCMP
+#
+$CMP CONN_01X38
+D Connector 01x38
+$ENDCMP
+#
+$CMP CONN_01X39
+D Connector 01x39
+$ENDCMP
+#
+$CMP CONN_01X40
+D Connector 01x40
+$ENDCMP
+#
+$CMP CONN_02X01
+D Connector 02x01
+$ENDCMP
+#
+$CMP CONN_02X02
+D Connector 02x02
+$ENDCMP
+#
+$CMP CONN_02X03
+D Connector 02x03
+$ENDCMP
+#
+$CMP CONN_02X04
+D Connector 02x04
+$ENDCMP
+#
+$CMP CONN_02X05
+D Connector 02x05
+$ENDCMP
+#
+$CMP CONN_02X06
+D Connector 02x06
+$ENDCMP
+#
+$CMP CONN_02X07
+D Connector 02x07
+$ENDCMP
+#
+$CMP CONN_02X08
+D Connector 02x08
+$ENDCMP
+#
+$CMP CONN_02X09
+D Connector 02x09
+$ENDCMP
+#
+$CMP CONN_02X10
+D Connector 02x10
+$ENDCMP
+#
+$CMP CONN_02X11
+D Connector 02x11
+$ENDCMP
+#
+$CMP CONN_02X12
+D Connector 02x12
+$ENDCMP
+#
+$CMP CONN_02X13
+D Connector 02x13
+$ENDCMP
+#
+$CMP CONN_02X14
+D Connector 02x14
+$ENDCMP
+#
+$CMP CONN_02X15
+D Connector 02x15
+$ENDCMP
+#
+$CMP CONN_02X16
+D Connector 02x16
+$ENDCMP
+#
+$CMP CONN_02X17
+D Connector 02x17
+$ENDCMP
+#
+$CMP CONN_02X18
+D Connector 02x18
+$ENDCMP
+#
+$CMP CONN_02X19
+D Connector 02x19
+$ENDCMP
+#
+$CMP CONN_02X20
+D Connector 02x20
+$ENDCMP
+#
+$CMP CONN_02X21
+D Connector 02x21
+$ENDCMP
+#
+$CMP CONN_02X22
+D Connector 02x22
+$ENDCMP
+#
+$CMP CONN_02X23
+D Connector 02x23
+$ENDCMP
+#
+$CMP CONN_02X24
+D Connector 02x24
+$ENDCMP
+#
+$CMP CONN_02X25
+D Connector 02x25
+$ENDCMP
+#
+$CMP CONN_02X26
+D Connector 02x26
+$ENDCMP
+#
+$CMP CONN_02X27
+D Connector 02x27
+$ENDCMP
+#
+$CMP CONN_02X28
+D Connector 02x28
+$ENDCMP
+#
+$CMP CONN_02X29
+D Connector 02x29
+$ENDCMP
+#
+$CMP CONN_02X30
+D Connector 02x30
+$ENDCMP
+#
+$CMP CONN_02X31
+D Connector 02x31
+$ENDCMP
+#
+$CMP CONN_02X32
+D Connector 02x32
+$ENDCMP
+#
+$CMP CONN_02X33
+D Connector 02x33
+$ENDCMP
+#
+$CMP CONN_02X34
+D Connector 02x34
+$ENDCMP
+#
+$CMP CONN_02X35
+D Connector 02x35
+$ENDCMP
+#
+$CMP CONN_02X36
+D Connector 02x36
+$ENDCMP
+#
+$CMP CONN_02X37
+D Connector 02x37
+$ENDCMP
+#
+$CMP CONN_02X38
+D Connector 02x38
+$ENDCMP
+#
+$CMP CONN_02X39
+D Connector 02x39
+$ENDCMP
+#
+$CMP CONN_02X40
+D Connector 02x40
+$ENDCMP
+#
 $CMP CONN_15X4
 D Connecteur Europe, 60 contacts, rangees A,B,C,D
 K CONN CONN


### PR DESCRIPTION
The connectors in conn.lib of the format CONN_01x02 (et al) were missing description text - I  have added this for each of these connectors.