### PR TITLE
Changed install path on osx

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,14 +5,11 @@ cmake_minimum_required( VERSION 2.6.1 FATAL_ERROR )
 # Locations for install targets.
 if( APPLE )
     # Like all variables, CMAKE_INSTALL_PREFIX can be over-ridden on the command line.
-    set( CMAKE_INSTALL_PREFIX /
-        CACHE PATH "" )
+    set( CMAKE_INSTALL_PREFIX "/Library/Application Support/kicad/" CACHE PATH "" )
     # Everything without leading / is relative to CMAKE_INSTALL_PREFIX.
-    set( KICAD_DATA "Library/Application Support/kicad/"
-        CACHE PATH "Location of KiCad data files." )
-    set( KICAD_MODULES ${KICAD_DATA}/modules )
-    set( KICAD_LIBRARY ${KICAD_DATA}/library )
-    set( KICAD_TEMPLATE ${KICAD_DATA}/template )
+    set( KICAD_MODULES modules )
+    set( KICAD_LIBRARY library )
+    set( KICAD_TEMPLATE template )
 else()
     # Everything without leading / is relative to CMAKE_INSTALL_PREFIX.
     set( KICAD_DATA share/kicad


### PR DESCRIPTION
Currently prefix is set to / and KICAD_DATA set to Library/Application Support/kicad This does not match the main kicad repo nor does it match any logical behaviour.

It makes more sense to remove KICAD_DATA as it can not be empty and just put the stuff in the prefix dir supplied. 

The only other sane option would be to have the prefix as /Library/Application Support with kicad_data as kicad/ but it doesn't seem much better.

This may need to be discussed or coordinated with adam prior to merge due to him having to change a line or 2 in his build scripts.
