### PR TITLE
Align grid with BeagleBone pins

### DIFF
--- a/template/BeagleBone-Black-Cape/BeagleBone-Black-Cape.kicad_pcb
+++ b/template/BeagleBone-Black-Cape/BeagleBone-Black-Cape.kicad_pcb
@@ -62,6 +62,7 @@
     (pad_drill 1.016)
     (pad_to_mask_clearance 0)
     (aux_axis_origin 0 0)
+    (grid_origin 116.3701 62.3824)
     (visible_elements 7FFFFFFF)
     (pcbplotparams
       (layerselection 0x01030_80000001)


### PR DESCRIPTION
This change sets the grid origin to the first pin on P9.  This allows
us to easily place components with the same pin spacing and alignment.