### PR TITLE
Adds a system that checks library rules automatically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 before_install:
--git clone https://github.com/KiCad/kicad-library-utils
--mv kicad-library-utils /usr/local/share/kicad-library-utils
+- git clone https://github.com/KiCad/kicad-library-utils
+- mv kicad-library-utils /usr/local/share/kicad-library-utils
 
 script:
-python /usr/local/share/kicad-library-utils/schlib/checklib.py ./library
+- python /usr/local/share/kicad-library-utils/schlib/checklib.py ./library

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,5 @@ before_install:
 - sudo mv kicad-library-utils /usr/local/share/kicad-library-utils
 
 script:
-- ls .
 - sudo bash ./library-check.sh
 - python /usr/local/share/kicad-library-utils/schlib/checklib.py -v ./library/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ before_install:
 - sudo mv kicad-library-utils /usr/local/share/kicad-library-utils
 
 script:
-- ./library-check.sh
+- sudo ./library-check.sh
 - python /usr/local/share/kicad-library-utils/schlib/checklib.py -v ./library/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ before_install:
 - sudo mv kicad-library-utils /usr/local/share/kicad-library-utils
 
 script:
-- python /usr/local/share/kicad-library-utils/schlib/checklib.py ./library
+- python /usr/local/share/kicad-library-utils/schlib/checklib.py ./library/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ before_install:
 - sudo mv kicad-library-utils /usr/local/share/kicad-library-utils
 
 script:
-- library-check.sh
+- ./library-check.sh
 - python /usr/local/share/kicad-library-utils/schlib/checklib.py -v ./library/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,3 @@ before_install:
 
 script:
 - sudo bash ./library-check.sh
-- python /usr/local/share/kicad-library-utils/schlib/checklib.py -v ./library/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ before_install:
 - sudo mv kicad-library-utils /usr/local/share/kicad-library-utils
 
 script:
+- ls .
 - sudo ./library-check.sh
 - python /usr/local/share/kicad-library-utils/schlib/checklib.py -v ./library/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ before_install:
 
 script:
 - ls .
-- sudo ./library-check.sh
+- ./library-check.sh
 - python /usr/local/share/kicad-library-utils/schlib/checklib.py -v ./library/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ before_install:
 - sudo mv kicad-library-utils /usr/local/share/kicad-library-utils
 
 script:
-- python /usr/local/share/kicad-library-utils/schlib/checklib.py ./library/*
+- python /usr/local/share/kicad-library-utils/schlib/checklib.py -v ./library/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ before_install:
 
 script:
 - ls .
-- ./library-check.sh
+- sudo bash ./library-check.sh
 - python /usr/local/share/kicad-library-utils/schlib/checklib.py -v ./library/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ before_install:
 - sudo mv kicad-library-utils /usr/local/share/kicad-library-utils
 
 script:
+- python /usr/local/share/kicad-library-utils/schlib/checklib.py
 - sudo bash ./library-check.sh
 - python /usr/local/share/kicad-library-utils/schlib/checklib.py -v ./library/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,5 @@ before_install:
 - sudo mv kicad-library-utils /usr/local/share/kicad-library-utils
 
 script:
-- python /usr/local/share/kicad-library-utils/schlib/checklib.py
 - sudo bash ./library-check.sh
 - python /usr/local/share/kicad-library-utils/schlib/checklib.py -v ./library/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
+sudo: required
 before_install:
 - git clone https://github.com/KiCad/kicad-library-utils
-- mv kicad-library-utils /usr/local/share/kicad-library-utils
+- sudo mv kicad-library-utils /usr/local/share/kicad-library-utils
 
 script:
 - python /usr/local/share/kicad-library-utils/schlib/checklib.py ./library

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 sudo: required
 before_install:
 - git clone https://github.com/KiCad/kicad-library-utils
+- git clone https://github.com/KiCad/kicad-library
+- sudo mv kicad-library /usr/local/share/kicad-library
 - sudo mv kicad-library-utils /usr/local/share/kicad-library-utils
 
 script:
+- library-check.sh
 - python /usr/local/share/kicad-library-utils/schlib/checklib.py -v ./library/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+before_install:
+-git clone https://github.com/KiCad/kicad-library-utils
+-mv kicad-library-utils /usr/local/share/kicad-library-utils
+
+script:
+python /usr/local/share/kicad-library-utils/schlib/checklib.py ./library

--- a/library-check.sh
+++ b/library-check.sh
@@ -1,7 +1,7 @@
 for OUTPUT in $(ls ./library/*.lib | wc -l)
 do
 	files=(./library/*.lib)
-	file=$(echo"${files[OUTPUT]}")
+	file=(echo"${files[OUTPUT]}")
 	echo $file
-	echo "python /usr/local/share/kicad-library-utils/schlib/comparelibs.py --new ./library/$file --original /usr/local/share/kicad-library/library/$file"
+	echo $python /usr/local/share/kicad-library-utils/schlib/comparelibs.py --new ./library/$file --original /usr/local/share/kicad-library/library/$file
 done

--- a/library-check.sh
+++ b/library-check.sh
@@ -3,5 +3,5 @@ do
 	files=(./library/*.lib)
 	echo"${files[OUTPUT]}"
 	echo $file
-	echo $python /usr/local/share/kicad-library-utils/schlib/comparelibs.py --new ./library/$file --original /usr/local/share/kicad-library/library/$file
+	echo $python /usr/local/share/kicad-library-utils/schlib/comparelibs.py --new ./library/${files[OUTPUT]} --original /usr/local/share/kicad-library/library/${files[OUTPUT]}
 done

--- a/library-check.sh
+++ b/library-check.sh
@@ -1,0 +1,6 @@
+for OUTPUT in $(ls ./library/*.lib | wc -l)
+do
+	files=(./library/*.lib)
+	file =  echo"${files[n]}"
+	python /usr/local/share/kicad-library-utils/schlib/comparelibs.py --new ./library/$file --original /usr/local/share/kicad-library/library/$file
+done

--- a/library-check.sh
+++ b/library-check.sh
@@ -1,7 +1,5 @@
-for OUTPUT in $(ls ./library/*.lib | wc -l)
-do
-	files=(./library/*.lib)
-	echo"${files[OUTPUT]}"
-	echo $file
+
+for file in *; do
+	files = "$file"
 	echo ${python /usr/local/share/kicad-library-utils/schlib/comparelibs.py --new ./library/${files[OUTPUT]} --original /usr/local/share/kicad-library/library/${files[OUTPUT]}}
 done

--- a/library-check.sh
+++ b/library-check.sh
@@ -1,5 +1,4 @@
 i=0
 for file in ./library/*.lib; do
-	files[$i]$file
 	echo python /usr/local/share/kicad-library-utils/schlib/comparelibs.py --new ./library/$file --original /usr/local/share/kicad-library/library/$file
 done

--- a/library-check.sh
+++ b/library-check.sh
@@ -1,5 +1,5 @@
-
+i=0
 for file in *; do
-	files = "$file"
-	echo ${python /usr/local/share/kicad-library-utils/schlib/comparelibs.py --new ./library/${files[OUTPUT]} --original /usr/local/share/kicad-library/library/${files[OUTPUT]}}
+	files[$i]$file
+	echo ${python /usr/local/share/kicad-library-utils/schlib/comparelibs.py --new ./library/$files --original /usr/local/share/kicad-library/library/$file
 done

--- a/library-check.sh
+++ b/library-check.sh
@@ -1,5 +1,5 @@
 i=0
 for file in *; do
 	files[$i]$file
-	echo ${python /usr/local/share/kicad-library-utils/schlib/comparelibs.py --new ./library/$files --original /usr/local/share/kicad-library/library/$file
+	echo ${python /usr/local/share/kicad-library-utils/schlib/comparelibs.py --new ./library/$files --original /usr/local/share/kicad-library/library/$file}
 done

--- a/library-check.sh
+++ b/library-check.sh
@@ -2,5 +2,6 @@ for OUTPUT in $(ls ./library/*.lib | wc -l)
 do
 	files=(./library/*.lib)
 	file=(echo"${files[OUTPUT]}")
+	echo $OUTPUT
 	python /usr/local/share/kicad-library-utils/schlib/comparelibs.py --new ./library/$file --original /usr/local/share/kicad-library/library/$file
 done

--- a/library-check.sh
+++ b/library-check.sh
@@ -2,5 +2,5 @@ i=0
 for file in ./library/*.lib; do
 	for item in sudo python /usr/local/share/kicad-library-utils/schlib/comparelibs.py --new ./library/$file --original /usr/local/share/kicad-library/library/$file; do
 		sudo python /usr/local/share/kicad-library-utils/schlib/checklib.py -c $item
-
+	done
 done

--- a/library-check.sh
+++ b/library-check.sh
@@ -1,7 +1,7 @@
 for OUTPUT in $(ls ./library/*.lib | wc -l)
 do
 	files=(./library/*.lib)
-	file=(echo"${files[OUTPUT]}")
+	file=$(echo"${files[OUTPUT]}")
 	echo $file
 	echo "python /usr/local/share/kicad-library-utils/schlib/comparelibs.py --new ./library/$file --original /usr/local/share/kicad-library/library/$file"
 done

--- a/library-check.sh
+++ b/library-check.sh
@@ -1,6 +1,7 @@
 i=0
 for file in ./library/*.lib; do
 	for item in sudo python /usr/local/share/kicad-library-utils/schlib/comparelibs.py --new ./library/$file --original /usr/local/share/kicad-library/library/$file; do
-		sudo python /usr/local/share/kicad-library-utils/schlib/checklib.py -c $item
+		echo $item
+	#	sudo python /usr/local/share/kicad-library-utils/schlib/checklib.py -c $item
 	done
 done

--- a/library-check.sh
+++ b/library-check.sh
@@ -1,5 +1,5 @@
 for file in ./library/*.lib; do
-	for item in $(python /usr/local/share/kicad-library-utils/schlib/comparelibs.py --new $file --original /usr/local/share/kicad-library/$file); do
+	for item in $(sudo python /usr/local/share/kicad-library-utils/schlib/comparelibs.py --new $file --original /usr/local/share/kicad-library/$file); do
 		echo $item
 		echo $file
 		sudo python /usr/local/share/kicad-library-utils/schlib/checklib.py $file -c $item

--- a/library-check.sh
+++ b/library-check.sh
@@ -1,6 +1,6 @@
 i=0
 for file in ./library/*.lib; do
-	for item in sudo python /usr/local/share/kicad-library-utils/schlib/comparelibs.py --new ./library/$file --original /usr/local/share/kicad-library/library/$file do
+	for item in sudo python /usr/local/share/kicad-library-utils/schlib/comparelibs.py --new ./library/$file --original /usr/local/share/kicad-library/library/$file; do
 		sudo python /usr/local/share/kicad-library-utils/schlib/checklib.py -c $item
 
 done

--- a/library-check.sh
+++ b/library-check.sh
@@ -3,5 +3,5 @@ do
 	files=(./library/*.lib)
 	file=(echo"${files[OUTPUT]}")
 	echo $OUTPUT
-	python /usr/local/share/kicad-library-utils/schlib/comparelibs.py --new ./library/$file --original /usr/local/share/kicad-library/library/$file
+	echo "python /usr/local/share/kicad-library-utils/schlib/comparelibs.py --new ./library/$file --original /usr/local/share/kicad-library/library/$file"
 done

--- a/library-check.sh
+++ b/library-check.sh
@@ -1,6 +1,6 @@
 i=0
 for file in ./library/*.lib; do
-	for item in sudo python /usr/local/share/kicad-library-utils/schlib/comparelibs.py --new ./library/$file --original /usr/local/share/kicad-library/library/$file; do
+	for item in "$sudo python /usr/local/share/kicad-library-utils/schlib/comparelibs.py --new ./library/$file --original /usr/local/share/kicad-library/library/$file"; do
 		echo $item
 	#	sudo python /usr/local/share/kicad-library-utils/schlib/checklib.py -c $item
 	done

--- a/library-check.sh
+++ b/library-check.sh
@@ -1,5 +1,6 @@
 i=0
 for file in ./library/*.lib; do
-	python /usr/local/share/kicad-library-utils/schlib/comparelibs.py --new ./library/$file --original /usr/local/share/kicad-library/library/$file
-	python /usr/local/share/kicad-library-utils/schlib/checklib.py -v ./library/*
+	for item in sudo python /usr/local/share/kicad-library-utils/schlib/comparelibs.py --new ./library/$file --original /usr/local/share/kicad-library/library/$file do
+		sudo python /usr/local/share/kicad-library-utils/schlib/checklib.py -c $item
+
 done

--- a/library-check.sh
+++ b/library-check.sh
@@ -2,6 +2,6 @@ for OUTPUT in $(ls ./library/*.lib | wc -l)
 do
 	files=(./library/*.lib)
 	file=(echo"${files[OUTPUT]}")
-	echo $OUTPUT
+	echo $file
 	echo "python /usr/local/share/kicad-library-utils/schlib/comparelibs.py --new ./library/$file --original /usr/local/share/kicad-library/library/$file"
 done

--- a/library-check.sh
+++ b/library-check.sh
@@ -1,5 +1,5 @@
 i=0
 for file in *; do
 	files[$i]$file
-	echo ${python /usr/local/share/kicad-library-utils/schlib/comparelibs.py --new ./library/$files --original /usr/local/share/kicad-library/library/$file}
+	echo python /usr/local/share/kicad-library-utils/schlib/comparelibs.py --new ./library/$files --original /usr/local/share/kicad-library/library/$file
 done

--- a/library-check.sh
+++ b/library-check.sh
@@ -1,4 +1,4 @@
 i=0
 for file in ./library/*.lib; do
-	echo python /usr/local/share/kicad-library-utils/schlib/comparelibs.py --new ./library/$file --original /usr/local/share/kicad-library/library/$file
+	python /usr/local/share/kicad-library-utils/schlib/comparelibs.py --new ./library/$file --original /usr/local/share/kicad-library/library/$file
 done

--- a/library-check.sh
+++ b/library-check.sh
@@ -1,6 +1,6 @@
 for OUTPUT in $(ls ./library/*.lib | wc -l)
 do
 	files=(./library/*.lib)
-	file =  echo"${files[n]}"
+	file=(echo"${files[n]}")
 	python /usr/local/share/kicad-library-utils/schlib/comparelibs.py --new ./library/$file --original /usr/local/share/kicad-library/library/$file
 done

--- a/library-check.sh
+++ b/library-check.sh
@@ -1,4 +1,5 @@
 i=0
 for file in ./library/*.lib; do
 	python /usr/local/share/kicad-library-utils/schlib/comparelibs.py --new ./library/$file --original /usr/local/share/kicad-library/library/$file
+	python /usr/local/share/kicad-library-utils/schlib/checklib.py -v ./library/*
 done

--- a/library-check.sh
+++ b/library-check.sh
@@ -1,5 +1,5 @@
 i=0
 for file in *; do
 	files[$i]$file
-	echo python /usr/local/share/kicad-library-utils/schlib/comparelibs.py --new ./library/$files --original /usr/local/share/kicad-library/library/$file
+	echo python /usr/local/share/kicad-library-utils/schlib/comparelibs.py --new ./library/$files[$i] --original /usr/local/share/kicad-library/library/$file[$i]
 done

--- a/library-check.sh
+++ b/library-check.sh
@@ -1,7 +1,7 @@
-i=0
 for file in ./library/*.lib; do
-	for item in "$sudo python /usr/local/share/kicad-library-utils/schlib/comparelibs.py --new ./library/$file --original /usr/local/share/kicad-library/library/$file"; do
+	for item in $(python /usr/local/share/kicad-library-utils/schlib/comparelibs.py --new $file --original /usr/local/share/kicad-library/$file); do
 		echo $item
-	#	sudo python /usr/local/share/kicad-library-utils/schlib/checklib.py -c $item
+		echo $file
+		sudo python /usr/local/share/kicad-library-utils/schlib/checklib.py $file -c $item
 	done
 done

--- a/library-check.sh
+++ b/library-check.sh
@@ -1,5 +1,5 @@
 i=0
-for file in *; do
+for file in ./library/*.lib; do
 	files[$i]$file
-	echo python /usr/local/share/kicad-library-utils/schlib/comparelibs.py --new ./library/$files[$i] --original /usr/local/share/kicad-library/library/$file[$i]
+	echo python /usr/local/share/kicad-library-utils/schlib/comparelibs.py --new ./library/$file --original /usr/local/share/kicad-library/library/$file
 done

--- a/library-check.sh
+++ b/library-check.sh
@@ -3,5 +3,5 @@ do
 	files=(./library/*.lib)
 	echo"${files[OUTPUT]}"
 	echo $file
-	echo $python /usr/local/share/kicad-library-utils/schlib/comparelibs.py --new ./library/${files[OUTPUT]} --original /usr/local/share/kicad-library/library/${files[OUTPUT]}
+	echo ${python /usr/local/share/kicad-library-utils/schlib/comparelibs.py --new ./library/${files[OUTPUT]} --original /usr/local/share/kicad-library/library/${files[OUTPUT]}}
 done

--- a/library-check.sh
+++ b/library-check.sh
@@ -1,6 +1,6 @@
 for OUTPUT in $(ls ./library/*.lib | wc -l)
 do
 	files=(./library/*.lib)
-	file=(echo"${files[n]}")
+	file=(echo"${files[OUTPUT]}")
 	python /usr/local/share/kicad-library-utils/schlib/comparelibs.py --new ./library/$file --original /usr/local/share/kicad-library/library/$file
 done

--- a/library-check.sh
+++ b/library-check.sh
@@ -1,7 +1,7 @@
 for OUTPUT in $(ls ./library/*.lib | wc -l)
 do
 	files=(./library/*.lib)
-	file=(echo"${files[OUTPUT]}")
+	echo"${files[OUTPUT]}"
 	echo $file
 	echo $python /usr/local/share/kicad-library-utils/schlib/comparelibs.py --new ./library/$file --original /usr/local/share/kicad-library/library/$file
 done

--- a/library/switches.lib
+++ b/library/switches.lib
@@ -1374,4 +1374,23 @@ X B 2 200 0 100 L 50 50 1 1 I
 ENDDRAW
 ENDDEF
 #
+# testingapart
+#
+DEF testingapart U 0 40 Y Y 1 F N
+F0 "U" 0 0 60 H V C CNN
+F1 "testingapart" 0 0 60 H V C CNN
+F2 "" 0 0 60 H I C CNN
+F3 "" 0 0 60 H I C CNN
+DRAW
+C 400 250 112 0 1 0 N
+C 400 250 200 0 1 0 N
+S 200 150 600 350 0 1 0 N
+S 550 50 300 450 0 1 0 N
+X ~ ~ 0 200 200 R 50 50 1 1 I
+X ~ ~ 0 300 200 R 50 50 1 1 I
+X ~ ~ 800 200 200 L 50 50 1 1 I
+X ~ ~ 800 300 200 L 50 50 1 1 I
+ENDDRAW
+ENDDEF
+#
 #End Library


### PR DESCRIPTION
This pull uses Travis-CI ([travis-ci.org](travis-ci.org)), a free continuous integration service, to run checklib.py from the kicad-library-utils repo. It pulls that file straight from the repo, so it will always remain up to date. 

The script is currently executing in verbose mode, so that an explanation of each error will appear. 

Currently there are tons of parts that violate rules 3.1, 3.6, and 3.9, so the output log is large. Fixing those will also mean it only shows an error if an addition is in violation. I will probably start working on fixing those for this reason.