### PR TITLE
Fix errant space in TNY part descriptions

### DIFF
--- a/library/powerint.dcm
+++ b/library/powerint.dcm
@@ -518,157 +518,157 @@ $ENDCMP
 #
 $CMP TNY263G
 D TinySwitch-II Family, 7.5W Output Power
-K Enhanced, Energy Effi cient, Low Power Off-line Switcher
+K Enhanced, Energy Efficient, Low Power Off-line Switcher
 F http://www.powerint.com/sites/default/files/product-docs/tny263_268.pdf
 $ENDCMP
 #
 $CMP TNY263P
 D TinySwitch-II Family, 7.5W Output Power
-K Enhanced, Energy Effi cient, Low Power Off-line Switcher
+K Enhanced, Energy Efficient, Low Power Off-line Switcher
 F http://www.powerint.com/sites/default/files/product-docs/tny263_268.pdf
 $ENDCMP
 #
 $CMP TNY264G
 D TinySwitch-II Family, 9W Output Power
-K Enhanced, Energy Effi cient, Low Power Off-line Switcher
+K Enhanced, Energy Efficient, Low Power Off-line Switcher
 F http://www.powerint.com/sites/default/files/product-docs/tny263_268.pdf
 $ENDCMP
 #
 $CMP TNY264P
 D TinySwitch-II Family, 9W Output Power
-K Enhanced, Energy Effi cient, Low Power Off-line Switcher
+K Enhanced, Energy Efficient, Low Power Off-line Switcher
 F http://www.powerint.com/sites/default/files/product-docs/tny263_268.pdf
 $ENDCMP
 #
 $CMP TNY265G
 D TinySwitch-II Family, 11W Output Power
-K Enhanced, Energy Effi cient, Low Power Off-line Switcher
+K Enhanced, Energy Efficient, Low Power Off-line Switcher
 F http://www.powerint.com/sites/default/files/product-docs/tny263_268.pdf
 $ENDCMP
 #
 $CMP TNY265P
 D TinySwitch-II Family, 11W Output Power
-K Enhanced, Energy Effi cient, Low Power Off-line Switcher
+K Enhanced, Energy Efficient, Low Power Off-line Switcher
 F http://www.powerint.com/sites/default/files/product-docs/tny263_268.pdf
 $ENDCMP
 #
 $CMP TNY266G
 D TinySwitch-II Family, 15W Output Power
-K Enhanced, Energy Effi cient, Low Power Off-line Switcher
+K Enhanced, Energy Efficient, Low Power Off-line Switcher
 F http://www.powerint.com/sites/default/files/product-docs/tny263_268.pdf
 $ENDCMP
 #
 $CMP TNY266P
 D TinySwitch-II Family, 15W Output Power
-K Enhanced, Energy Effi cient, Low Power Off-line Switcher
+K Enhanced, Energy Efficient, Low Power Off-line Switcher
 F http://www.powerint.com/sites/default/files/product-docs/tny263_268.pdf
 $ENDCMP
 #
 $CMP TNY267G
 D TinySwitch-II Family, 19W Output Power
-K Enhanced, Energy Effi cient, Low Power Off-line Switcher
+K Enhanced, Energy Efficient, Low Power Off-line Switcher
 F http://www.powerint.com/sites/default/files/product-docs/tny263_268.pdf
 $ENDCMP
 #
 $CMP TNY267P
 D TinySwitch-II Family, 19W Output Power
-K Enhanced, Energy Effi cient, Low Power Off-line Switcher
+K Enhanced, Energy Efficient, Low Power Off-line Switcher
 F http://www.powerint.com/sites/default/files/product-docs/tny263_268.pdf
 $ENDCMP
 #
 $CMP TNY268G
 D TinySwitch-II Family, 23W Output Power
-K Enhanced, Energy Effi cient, Low Power Off-line Switcher
+K Enhanced, Energy Efficient, Low Power Off-line Switcher
 F http://www.powerint.com/sites/default/files/product-docs/tny263_268.pdf
 $ENDCMP
 #
 $CMP TNY268P
 D TinySwitch-II Family, 23W Output Power
-K Enhanced, Energy Effi cient, Low Power Off-line Switcher
+K Enhanced, Energy Efficient, Low Power Off-line Switcher
 F http://www.powerint.com/sites/default/files/product-docs/tny263_268.pdf
 $ENDCMP
 #
 $CMP TNY274G
 D TinySwitch-III Family, 8.5W Output Power
-K Energy-Effi cient, Off-Line Switcher With Enhanced Flexibility and Extended Power Range
+K Energy-Efficient, Off-Line Switcher With Enhanced Flexibility and Extended Power Range
 F http://www.powerint.com/sites/default/files/product-docs/tny274-280.pdf
 $ENDCMP
 #
 $CMP TNY274P
 D TinySwitch-III Family, 8.5W Output Power
-K Energy-Effi cient, Off-Line Switcher With Enhanced Flexibility and Extended Power Range
+K Energy-Efficient, Off-Line Switcher With Enhanced Flexibility and Extended Power Range
 F http://www.powerint.com/sites/default/files/product-docs/tny274-280.pdf
 $ENDCMP
 #
 $CMP TNY275G
 D TinySwitch-III Family, 11.5W Output Power
-K Energy-Effi cient, Off-Line Switcher With Enhanced Flexibility and Extended Power Range
+K Energy-Efficient, Off-Line Switcher With Enhanced Flexibility and Extended Power Range
 F http://www.powerint.com/sites/default/files/product-docs/tny274-280.pdf
 $ENDCMP
 #
 $CMP TNY275P
 D TinySwitch-III Family, 11.5W Output Power
-K Energy-Effi cient, Off-Line Switcher With Enhanced Flexibility and Extended Power Range
+K Energy-Efficient, Off-Line Switcher With Enhanced Flexibility and Extended Power Range
 F http://www.powerint.com/sites/default/files/product-docs/tny274-280.pdf
 $ENDCMP
 #
 $CMP TNY276G
 D TinySwitch-III Family, 15W Output Power
-K Energy-Effi cient, Off-Line Switcher With Enhanced Flexibility and Extended Power Range
+K Energy-Efficient, Off-Line Switcher With Enhanced Flexibility and Extended Power Range
 F http://www.powerint.com/sites/default/files/product-docs/tny274-280.pdf
 $ENDCMP
 #
 $CMP TNY276P
 D TinySwitch-III Family, 15W Output Power
-K Energy-Effi cient, Off-Line Switcher With Enhanced Flexibility and Extended Power Range
+K Energy-Efficient, Off-Line Switcher With Enhanced Flexibility and Extended Power Range
 F http://www.powerint.com/sites/default/files/product-docs/tny274-280.pdf
 $ENDCMP
 #
 $CMP TNY277G
 D TinySwitch-III Family, 18W Output Power
-K Energy-Effi cient, Off-Line Switcher With Enhanced Flexibility and Extended Power Range
+K Energy-Efficient, Off-Line Switcher With Enhanced Flexibility and Extended Power Range
 F http://www.powerint.com/sites/default/files/product-docs/tny274-280.pdf
 $ENDCMP
 #
 $CMP TNY277P
 D TinySwitch-III Family, 18W Output Power
-K Energy-Effi cient, Off-Line Switcher With Enhanced Flexibility and Extended Power Range
+K Energy-Efficient, Off-Line Switcher With Enhanced Flexibility and Extended Power Range
 F http://www.powerint.com/sites/default/files/product-docs/tny274-280.pdf
 $ENDCMP
 #
 $CMP TNY278G
 D TinySwitch-III Family, 21.5W Output Power
-K Energy-Effi cient, Off-Line Switcher With Enhanced Flexibility and Extended Power Range
+K Energy-Efficient, Off-Line Switcher With Enhanced Flexibility and Extended Power Range
 F http://www.powerint.com/sites/default/files/product-docs/tny274-280.pdf
 $ENDCMP
 #
 $CMP TNY278P
 D TinySwitch-III Family, 21.5W Output Power
-K Energy-Effi cient, Off-Line Switcher With Enhanced Flexibility and Extended Power Range
+K Energy-Efficient, Off-Line Switcher With Enhanced Flexibility and Extended Power Range
 F http://www.powerint.com/sites/default/files/product-docs/tny274-280.pdf
 $ENDCMP
 #
 $CMP TNY279G
 D TinySwitch-III Family, 25W Output Power
-K Energy-Effi cient, Off-Line Switcher With Enhanced Flexibility and Extended Power Range
+K Energy-Efficient, Off-Line Switcher With Enhanced Flexibility and Extended Power Range
 F http://www.powerint.com/sites/default/files/product-docs/tny274-280.pdf
 $ENDCMP
 #
 $CMP TNY279P
 D TinySwitch-III Family, 25W Output Power
-K Energy-Effi cient, Off-Line Switcher With Enhanced Flexibility and Extended Power Range
+K Energy-Efficient, Off-Line Switcher With Enhanced Flexibility and Extended Power Range
 F http://www.powerint.com/sites/default/files/product-docs/tny274-280.pdf
 $ENDCMP
 #
 $CMP TNY280G
 D TinySwitch-III Family, 28.5W Output Power
-K Energy-Effi cient, Off-Line Switcher With Enhanced Flexibility and Extended Power Range
+K Energy-Efficient, Off-Line Switcher With Enhanced Flexibility and Extended Power Range
 F http://www.powerint.com/sites/default/files/product-docs/tny274-280.pdf
 $ENDCMP
 #
 $CMP TNY280P
 D TinySwitch-III Family, 28.5W Output Power
-K Energy-Effi cient, Off-Line Switcher With Enhanced Flexibility and Extended Power Range
+K Energy-Efficient, Off-Line Switcher With Enhanced Flexibility and Extended Power Range
 F http://www.powerint.com/sites/default/files/product-docs/tny274-280.pdf
 $ENDCMP
 #


### PR DESCRIPTION
Change "Effi cient" to "Efficient".