### PR TITLE
Make the 'pin header' connectors easier to find for (new) users

### DIFF
--- a/library/conn.dcm
+++ b/library/conn.dcm
@@ -36,442 +36,442 @@ K connector
 $ENDCMP
 #
 $CMP CONN_01X01
-D Connector, single row, 01x01
+D Connector, single row, 01x01, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_01X01_FEMALE
-D Generic Female Connector, Single Row, 01x01
+D Generic Female Connector, Single Row, 01x01, socket header
 K Connector, Female, Generic
 $ENDCMP
 #
 $CMP CONN_01X01_MALE
-D Generic Male Connector, single row,  01x01
+D Generic Male Connector, single row, 01x01, pin header
 K Connector, Male, Generic
 $ENDCMP
 #
 $CMP CONN_01X02
-D Connector, single row, 01x02
+D Connector, single row, 01x02, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_01X02_FEMALE
-D Generic Female Connector, Single Row,  01x02
+D Generic Female Connector, Single Row, 01x02, socket header
 K Connector, Female, Generic
 $ENDCMP
 #
 $CMP CONN_01X02_MALE
-D Generic Male Connector, single row,  01x02
+D Generic Male Connector, single row, 01x02, pin header
 K Connector, Male, Generic
 $ENDCMP
 #
 $CMP CONN_01X03
-D Connector, single row, 01x03
+D Connector, single row, 01x03, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_01X03_FEMALE
-D Generic Female Connector, Single Row,  01x03
+D Generic Female Connector, Single Row, 01x03, socket header
 K Connector, Female, Generic
 $ENDCMP
 #
 $CMP CONN_01X03_MALE
-D Generic Male Connector, single row,  01x03
+D Generic Male Connector, single row, 01x03, pin header
 K Connector, Male, Generic
 $ENDCMP
 #
 $CMP CONN_01X04
-D Connector, single row, 01x04
+D Connector, single row, 01x04, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_01X04_FEMALE
-D Generic Female Connector, Single Row,  01x04
+D Generic Female Connector, Single Row, 01x04, socket header
 K Connector, Female, Generic
 $ENDCMP
 #
 $CMP CONN_01X04_MALE
-D Generic Male Connector, single row,  01x04
+D Generic Male Connector, single row, 01x04, pin header
 K Connector, Male, Generic
 $ENDCMP
 #
 $CMP CONN_01X05
-D Connector, single row, 01x05
+D Connector, single row, 01x05, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_01X06
-D Connector, single row, 01x06
+D Connector, single row, 01x06, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_01X07
-D Connector, single row, 01x07
+D Connector, single row, 01x07, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_01X08
-D Connector, single row, 01x08
+D Connector, single row, 01x08, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_01X09
-D Connector, single row, 01x09
+D Connector, single row, 01x09, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_01X10
-D Connector, single row, 01x10
+D Connector, single row, 01x10, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_01X11
-D Connector, single row, 01x11
+D Connector, single row, 01x11, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_01X12
-D Connector, single row, 01x12
+D Connector, single row, 01x12, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_01X13
-D Connector, single row, 01x13
+D Connector, single row, 01x13, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_01X14
-D Connector, single row, 01x14
+D Connector, single row, 01x14, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_01X15
-D Connector, single row, 01x15
+D Connector, single row, 01x15, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_01X16
-D Connector, single row, 01x16
+D Connector, single row, 01x16, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_01X17
-D Connector, single row, 01x17
+D Connector, single row, 01x17, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_01X18
-D Connector, single row, 01x18
+D Connector, single row, 01x18, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_01X19
-D Connector, single row, 01x19
+D Connector, single row, 01x19, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_01X20
-D Connector, single row, 01x20
+D Connector, single row, 01x20, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_01X21
-D Connector, single row, 01x21
+D Connector, single row, 01x21, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_01X22
-D Connector, single row, 01x22
+D Connector, single row, 01x22, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_01X23
-D Connector, single row, 01x23
+D Connector, single row, 01x23, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_01X24
-D Connector, single row, 01x24
+D Connector, single row, 01x24, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_01X25
-D Connector, single row, 01x25
+D Connector, single row, 01x25, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_01X26
-D Connector, single row, 01x26
+D Connector, single row, 01x26, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_01X27
-D Connector, single row, 01x27
+D Connector, single row, 01x27, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_01X28
-D Connector, single row, 01x28
+D Connector, single row, 01x28, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_01X29
-D Connector, single row, 01x29
+D Connector, single row, 01x29, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_01X30
-D Connector, single row, 01x30
+D Connector, single row, 01x30, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_01X31
-D Connector, single row, 01x31
+D Connector, single row, 01x31, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_01X32
-D Connector, single row, 01x32
+D Connector, single row, 01x32, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_01X33
-D Connector, single row, 01x33
+D Connector, single row, 01x33, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_01X34
-D Connector, single row, 01x34
+D Connector, single row, 01x34, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_01X35
-D Connector, single row, 01x35
+D Connector, single row, 01x35, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_01X36
-D Connector, single row, 01x36
+D Connector, single row, 01x36, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_01X37
-D Connector, single row, 01x37
+D Connector, single row, 01x37, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_01X38
-D Connector, single row, 01x38
+D Connector, single row, 01x38, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_01X39
-D Connector, single row, 01x39
+D Connector, single row, 01x39, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_01X40
-D Connector, single row, 01x40
+D Connector, single row, 01x40, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_02X01
-D Connector, double row, 02x01
+D Connector, double row, 02x01, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_02X02
-D Connector, double row, 02x02
+D Connector, double row, 02x02, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_02X03
-D Connector, double row, 02x03
+D Connector, double row, 02x03, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_02X04
-D Connector, double row, 02x04
+D Connector, double row, 02x04, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_02X05
-D Connector, double row, 02x05
+D Connector, double row, 02x05, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_02X06
-D Connector, double row, 02x06
+D Connector, double row, 02x06, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_02X07
-D Connector, double row, 02x07
+D Connector, double row, 02x07, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_02X08
-D Connector, double row, 02x08
+D Connector, double row, 02x08, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_02X09
-D Connector, double row, 02x09
+D Connector, double row, 02x09, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_02X10
-D Connector, double row, 02x10
+D Connector, double row, 02x10, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_02X11
-D Connector, double row, 02x11
+D Connector, double row, 02x11, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_02X12
-D Connector, double row, 02x12
+D Connector, double row, 02x12, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_02X13
-D Connector, double row, 02x13
+D Connector, double row, 02x13, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_02X14
-D Connector, double row, 02x14
+D Connector, double row, 02x14, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_02X15
-D Connector, double row, 02x15
+D Connector, double row, 02x15, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_02X16
-D Connector, double row, 02x16
+D Connector, double row, 02x16, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_02X17
-D Connector, double row, 02x17
+D Connector, double row, 02x17, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_02X18
-D Connector, double row, 02x18
+D Connector, double row, 02x18, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_02X19
-D Connector, double row, 02x19
+D Connector, double row, 02x19, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_02X20
-D Connector, double row, 02x20
+D Connector, double row, 02x20, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_02X21
-D Connector, double row, 02x21
+D Connector, double row, 02x21, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_02X22
-D Connector, double row, 02x22
+D Connector, double row, 02x22, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_02X23
-D Connector, double row, 02x23
+D Connector, double row, 02x23, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_02X24
-D Connector, double row, 02x24
+D Connector, double row, 02x24, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_02X25
-D Connector, double row, 02x25
+D Connector, double row, 02x25, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_02X26
-D Connector, double row, 02x26
+D Connector, double row, 02x26, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_02X27
-D Connector, double row, 02x27
+D Connector, double row, 02x27, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_02X28
-D Connector, double row, 02x28
+D Connector, double row, 02x28, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_02X29
-D Connector, double row, 02x29
+D Connector, double row, 02x29, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_02X30
-D Connector, double row, 02x30
+D Connector, double row, 02x30, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_02X31
-D Connector, double row, 02x31
+D Connector, double row, 02x31, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_02X32
-D Connector, double row, 02x32
+D Connector, double row, 02x32, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_02X33
-D Connector, double row, 02x33
+D Connector, double row, 02x33, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_02X34
-D Connector, double row, 02x34
+D Connector, double row, 02x34, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_02X35
-D Connector, double row, 02x35
+D Connector, double row, 02x35, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_02X36
-D Connector, double row, 02x36
+D Connector, double row, 02x36, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_02X37
-D Connector, double row, 02x37
+D Connector, double row, 02x37, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_02X38
-D Connector, double row, 02x38
+D Connector, double row, 02x38, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_02X39
-D Connector, double row, 02x39
+D Connector, double row, 02x39, pin header
 K connector
 $ENDCMP
 #
 $CMP CONN_02X40
-D Connector, double row, 02x40
+D Connector, double row, 02x40, pin header
 K connector
 $ENDCMP
 #


### PR DESCRIPTION
Some users expect to find the CONN_ symbols through the name "header" or "pin header."
Make sure to remove this snag from the on-boarding path to KiCad by adding that term to the description of the CONN_ components.
For example, Open Parts Library, SparkFun, Seeed, Jameco, and EAGLE all use variants of this name.