### PR TITLE
Add footprint filters for IDC headers.

### DIFF
--- a/library/conn.lib
+++ b/library/conn.lib
@@ -3018,6 +3018,7 @@ $FPLIST
  Pin_Header_Angled_2X*
  Socket_Strip_Straight_2X*
  Socket_Strip_Angled_2X*
+ IDC_Header_Straight_*
 $ENDFPLIST
 DRAW
 S -100 -95 -50 -105 0 1 0 N
@@ -3048,6 +3049,7 @@ $FPLIST
  Pin_Header_Angled_2X*
  Socket_Strip_Straight_2X*
  Socket_Strip_Angled_2X*
+ IDC_Header_Straight_*
 $ENDFPLIST
 DRAW
 S -100 -145 -50 -155 0 1 0 N
@@ -3082,6 +3084,7 @@ $FPLIST
  Pin_Header_Angled_2X*
  Socket_Strip_Straight_2X*
  Socket_Strip_Angled_2X*
+ IDC_Header_Straight_*
 $ENDFPLIST
 DRAW
 S -100 -195 -50 -205 0 1 0 N
@@ -3120,6 +3123,7 @@ $FPLIST
  Pin_Header_Angled_2X*
  Socket_Strip_Straight_2X*
  Socket_Strip_Angled_2X*
+ IDC_Header_Straight_*
 $ENDFPLIST
 DRAW
 S -100 -245 -50 -255 0 1 0 N
@@ -3162,6 +3166,7 @@ $FPLIST
  Pin_Header_Angled_2X*
  Socket_Strip_Straight_2X*
  Socket_Strip_Angled_2X*
+ IDC_Header_Straight_*
 $ENDFPLIST
 DRAW
 S -100 -295 -50 -305 0 1 0 N
@@ -3208,6 +3213,7 @@ $FPLIST
  Pin_Header_Angled_2X*
  Socket_Strip_Straight_2X*
  Socket_Strip_Angled_2X*
+ IDC_Header_Straight_*
 $ENDFPLIST
 DRAW
 S -100 -345 -50 -355 0 1 0 N
@@ -3312,6 +3318,7 @@ $FPLIST
  Pin_Header_Angled_2X*
  Socket_Strip_Straight_2X*
  Socket_Strip_Angled_2X*
+ IDC_Header_Straight_*
 $ENDFPLIST
 DRAW
 S -100 -445 -50 -455 0 1 0 N
@@ -3498,6 +3505,7 @@ $FPLIST
  Pin_Header_Angled_2X*
  Socket_Strip_Straight_2X*
  Socket_Strip_Angled_2X*
+ IDC_Header_Straight_*
 $ENDFPLIST
 DRAW
 S -100 -595 -50 -605 0 1 0 N
@@ -3642,6 +3650,7 @@ $FPLIST
  Pin_Header_Angled_2X*
  Socket_Strip_Straight_2X*
  Socket_Strip_Angled_2X*
+ IDC_Header_Straight_*
 $ENDFPLIST
 DRAW
 S -100 -695 -50 -705 0 1 0 N
@@ -3802,6 +3811,7 @@ $FPLIST
  Pin_Header_Angled_2X*
  Socket_Strip_Straight_2X*
  Socket_Strip_Angled_2X*
+ IDC_Header_Straight_*
 $ENDFPLIST
 DRAW
 S -100 -795 -50 -805 0 1 0 N
@@ -4072,6 +4082,7 @@ $FPLIST
  Pin_Header_Angled_2X*
  Socket_Strip_Straight_2X*
  Socket_Strip_Angled_2X*
+ IDC_Header_Straight_*
 $ENDFPLIST
 DRAW
 S -100 -945 -50 -955 0 1 0 N
@@ -4602,6 +4613,7 @@ $FPLIST
  Pin_Header_Angled_2X*
  Socket_Strip_Straight_2X*
  Socket_Strip_Angled_2X*
+ IDC_Header_Straight_*
 $ENDFPLIST
 DRAW
 S -100 -1195 -50 -1205 0 1 0 N
@@ -5232,6 +5244,7 @@ $FPLIST
  Pin_Header_Angled_2X*
  Socket_Strip_Straight_2X*
  Socket_Strip_Angled_2X*
+ IDC_Header_Straight_*
 $ENDFPLIST
 DRAW
 S -100 -1445 -50 -1455 0 1 0 N
@@ -5512,6 +5525,7 @@ $FPLIST
  Pin_Header_Angled_2X*
  Socket_Strip_Straight_2X*
  Socket_Strip_Angled_2X*
+ IDC_Header_Straight_*
 $ENDFPLIST
 DRAW
 S -100 -1545 -50 -1555 0 1 0 N


### PR DESCRIPTION
There are IDC header footprints in library already. This PR adds the filters for these footprints to pin header symbols.