### PR TITLE
Added missing parenthesis

### DIFF
--- a/template/fp-lib-table.for-pretty
+++ b/template/fp-lib-table.for-pretty
@@ -66,7 +66,7 @@
   (lib (name Oddities)(type KiCad)(uri ${KISYSMOD}/Oddities.pretty)(options "")(descr "Assorted footprints. Deprecated - will be removed"))
   (lib (name Opto-Devices)(type KiCad)(uri ${KISYSMOD}/Opto-Devices.pretty)(options "")(descr "Optocouplers, light sensors, and other optical devices"))
   (lib (name Oscillators)(type KiCad)(uri ${KISYSMOD}/Oscillators.pretty)(options "")(descr "Precicision oscillator modules"))
-  (lib (name PFF_PSF_PSS_Leadforms)(type KiCad)(uri ${KISYSMOD}/PFF_PSF_PSS_Leadforms.pretty)(options "")(descr "Allegro leadform packages")
+  (lib (name PFF_PSF_PSS_Leadforms)(type KiCad)(uri ${KISYSMOD}/PFF_PSF_PSS_Leadforms.pretty)(options "")(descr "Allegro leadform packages"))
   (lib (name Pin_Headers)(type KiCad)(uri ${KISYSMOD}/Pin_Headers.pretty)(options "")(descr "Male pin headers"))
   (lib (name Potentiometers)(type KiCad)(uri ${KISYSMOD}/Potentiometers.pretty)(options "")(descr "Potentiometers / variable resistors"))
   (lib (name Power_Integrations)(type KiCad)(uri ${KISYSMOD}/Power_Integrations.pretty)(options "")(descr "Power Integrations footprints"))


### PR DESCRIPTION
There is a missing parenthesis in the kicad lib table file which is causing import errors. 