### PR TITLE
Remove TOP262YN as it's not a real part

### DIFF
--- a/library/powerint.dcm
+++ b/library/powerint.dcm
@@ -1392,12 +1392,6 @@ K Eco Smart Off-Line Switcher, Extendend Power Range
 F https://ac-dc.power.com/sites/default/files/product-docs/topswitch-hx_family_datasheet.pdf
 $ENDCMP
 #
-$CMP TOP262YN
-D TOPSwitch-HX Family, 254W Output Power
-K Eco Smart Off-Line Switcher, Extendend Power Range
-F https://ac-dc.power.com/sites/default/files/product-docs/topswitch-hx_family_datasheet.pdf
-$ENDCMP
-#
 $CMP TOP264EG
 D TOPSwitch-JX Family, 43W Output Power, eSIP-7C
 K Integrated Off-Line Switcher with EcoSmart™ Technology


### PR DESCRIPTION
As noted by @diggit in issue #1006. Checking the part datasheet, TOP262 is not available in the YN package so this must have been a mistake when updating the powerint library.