### PR TITLE
Fixes for .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,11 @@
-*   text=lf
+*   text=auto
 *.wrl   -diff
 *.pack  binary
 *.png   binary
 *.step  binary
+*.stp   binary
+*.STEP  binary
+*.STP   binary
 *.wings binary
 *.svg   binary
 *.pdf   binary


### PR DESCRIPTION
Testing reveals that "* text=auto" provides best results. If this fixes the line-ending issues  we can push this file out to the .pretty repos too.