### PR TITLE
Added missing library table entries

### DIFF
--- a/template/fp-lib-table.for-github
+++ b/template/fp-lib-table.for-github
@@ -1,5 +1,6 @@
 (fp_lib_table
   (lib (name Air_Coils_SML_NEOSID)(type Github)(uri ${KIGITHUB}/Air_Coils_SML_NEOSID.pretty)(options "")(descr "Deprecated - will be removed"))
+  (lib (name Battery_Holders)(type Github)(uri ${KIGITHUB}/Battery_Holders.pretty)(options "")(descr "Batteries and battery holders"))
   (lib (name Buttons_Switches_SMD)(type Github)(uri ${KIGITHUB}/Buttons_Switches_SMD.pretty)(options "")(descr "Buttons and switches, surface mount"))
   (lib (name Buttons_Switches_THT)(type Github)(uri ${KIGITHUB}/Buttons_Switches_THT.pretty)(options "")(descr "Buttons and switches, through hole"))
   (lib (name Buzzers_Beepers)(type Github)(uri ${KIGITHUB}/Buzzers_Beepers.pretty)(options "")(descr "Audio signalling devices"))
@@ -40,6 +41,7 @@
   (lib (name Hall-Effect_Transducers_LEM)(type Github)(uri ${KIGITHUB}/Hall-Effect_Transducers_LEM.pretty)(options "")(descr "LEM hall effect transducers"))
   (lib (name Heatsinks)(type Github)(uri ${KIGITHUB}/Heatsinks.pretty)(options "")(descr "Heatsinks and thermal products"))
   (lib (name Housings_BGA)(type Github)(uri ${KIGITHUB}/Housings_BGA.pretty)(options "")(descr "Ball Grid Array (BGA)"))
+  (lib (name Housings_CSP)(type Github)(uri ${KIGITHUB}/Housings_CSP.pretty)(options "")(descr "Chip Scale Packages (CSP)"))
   (lib (name Housings_DFN_QFN)(type Github)(uri ${KIGITHUB}/Housings_DFN_QFN.pretty)(options "")(descr "Surface mount IC packages, DFN / LGA / QFN"))
   (lib (name Housings_DIP)(type Github)(uri ${KIGITHUB}/Housings_DIP.pretty)(options "")(descr "Through hole IC packages, DIP"))
   (lib (name Housings_LCC)(type Github)(uri ${KIGITHUB}/Housings_LCC.pretty)(options "")(descr "Leaded Chip Carriers (LCC)"))

--- a/template/fp-lib-table.for-pretty
+++ b/template/fp-lib-table.for-pretty
@@ -1,5 +1,6 @@
 (fp_lib_table
   (lib (name Air_Coils_SML_NEOSID)(type KiCad)(uri ${KISYSMOD}/Air_Coils_SML_NEOSID.pretty)(options "")(descr "Deprecated - will be removed"))
+  (lib (name Battery_Holders)(type KiCad)(uri ${KISYSMOD}/Battery_Holders.pretty)(options "")(descr "Batteries and battery holders"))
   (lib (name Buttons_Switches_SMD)(type KiCad)(uri ${KISYSMOD}/Buttons_Switches_SMD.pretty)(options "")(descr "Buttons and switches, surface mount"))
   (lib (name Buttons_Switches_THT)(type KiCad)(uri ${KISYSMOD}/Buttons_Switches_THT.pretty)(options "")(descr "Buttons and switches, through hole"))
   (lib (name Buzzers_Beepers)(type KiCad)(uri ${KISYSMOD}/Buzzers_Beepers.pretty)(options "")(descr "Audio signalling devices"))
@@ -40,6 +41,7 @@
   (lib (name Hall-Effect_Transducers_LEM)(type KiCad)(uri ${KISYSMOD}/Hall-Effect_Transducers_LEM.pretty)(options "")(descr "LEM hall effect transducers"))
   (lib (name Heatsinks)(type KiCad)(uri ${KISYSMOD}/Heatsinks.pretty)(options "")(descr "Heatsinks and thermal products"))
   (lib (name Housings_BGA)(type KiCad)(uri ${KISYSMOD}/Housings_BGA.pretty)(options "")(descr "Ball Grid Array (BGA)"))
+  (lib (name Housings_CSP)(type KiCad)(uri ${KISYSMOD}/Housings_CSP.pretty)(options "")(descr "Chip Scale Packages (CSP)"))
   (lib (name Housings_DFN_QFN)(type KiCad)(uri ${KISYSMOD}/Housings_DFN_QFN.pretty)(options "")(descr "Surface mount IC packages, DFN / LGA / QFN"))
   (lib (name Housings_DIP)(type KiCad)(uri ${KISYSMOD}/Housings_DIP.pretty)(options "")(descr "Through hole IC packages, DIP"))
   (lib (name Housings_LCC)(type KiCad)(uri ${KISYSMOD}/Housings_LCC.pretty)(options "")(descr "Leaded Chip Carriers (LCC)"))


### PR DESCRIPTION
This PR adds missing .pretty repos to the lib tables:

* Battery Holders
* Housings_CSP