### PR TITLE
Added lib-table entry for Connectors_USB library

### DIFF
--- a/template/fp-lib-table.for-github
+++ b/template/fp-lib-table.for-github
@@ -24,6 +24,7 @@
   (lib (name Connectors_TE-Connectivity)(type Github)(uri ${KIGITHUB}/Connectors_TE-Connectivity.pretty)(options "")(descr "TE Connectivity connector footprints www.te.com"))
   (lib (name Connectors_Terminal_Blocks)(type Github)(uri ${KIGITHUB}/Connectors_Terminal_Blocks.pretty)(options "")(descr "Terminal block connectors"))
   (lib (name Connectors_WAGO)(type Github)(uri ${KIGITHUB}/Connectors_WAGO.pretty)(options "")(descr "WAGO connector footprints www.wago.com"))
+  (lib (name Connectors_USB)(type Github)(uri ${KIGITHUB}/Connectors_USB.pretty)(options "")(descr "USB connector footprints"))
   (lib (name Connectors)(type Github)(uri ${KIGITHUB}/Connectors.pretty)(options "")(descr "Assorted connector footprints"))
   (lib (name Converters_DCDC_ACDC)(type Github)(uri ${KIGITHUB}/Converters_DCDC_ACDC.pretty)(options "")(descr "DC-DC and AC-DC convertor modules"))
   (lib (name Crystals)(type Github)(uri ${KIGITHUB}/Crystals.pretty)(options "")(descr "Crystals and oscillators"))

--- a/template/fp-lib-table.for-pretty
+++ b/template/fp-lib-table.for-pretty
@@ -24,6 +24,7 @@
   (lib (name Connectors_TE-Connectivity)(type KiCad)(uri ${KISYSMOD}/Connectors_TE-Connectivity.pretty)(options "")(descr "TE Connectivity connector footprints www.te.com"))
   (lib (name Connectors_Terminal_Blocks)(type KiCad)(uri ${KISYSMOD}/Connectors_Terminal_Blocks.pretty)(options "")(descr "Terminal block connectors"))
   (lib (name Connectors_WAGO)(type KiCad)(uri ${KISYSMOD}/Connectors_WAGO.pretty)(options "")(descr "WAGO connector footprints www.wago.com"))
+  (lib (name Connectors_USB)(type KiCad)(uri ${KISYSMOD}/Connectors_USB.pretty)(options "")(descr "USB connector footprints"))
   (lib (name Connectors)(type KiCad)(uri ${KISYSMOD}/Connectors.pretty)(options "")(descr "Assorted connector footprints"))
   (lib (name Converters_DCDC_ACDC)(type KiCad)(uri ${KISYSMOD}/Converters_DCDC_ACDC.pretty)(options "")(descr "DC-DC and AC-DC convertor modules"))
   (lib (name Crystals)(type KiCad)(uri ${KISYSMOD}/Crystals.pretty)(options "")(descr "Crystals and oscillators"))


### PR DESCRIPTION
This PR adds lib-table entry for the new [Connectors_USB](https://github.com/KiCad/Connectors_USB.pretty) library