### PR TITLE
Update OMRON Relays for KLC compliance

### DIFF
--- a/library/relays.dcm
+++ b/library/relays.dcm
@@ -91,13 +91,13 @@ F https://www.elpro.org/de/index.php?controller=attachment&id_attachment=8663
 $ENDCMP
 #
 $CMP G5Q-1
-D OMRON G5G-1, Miniature Single Pole Relay, SPDT, 10A
+D G5G relay, Miniature Single Pole, SPDT, 10A
 K Miniature Single Pole Relay
 F https://www.omron.com/ecb/products/pdf/en-g5q.pdf
 $ENDCMP
 #
 $CMP G5Q-1A
-D G5G-1A, Miniature Single Pole Relay, SPST-NO, 10A
+D G5Q relay, Miniature Single Pole, SPST-NO, 10A
 K Miniature Single Pole Relay
 F https://www.omron.com/ecb/products/pdf/en-g5q.pdf
 $ENDCMP
@@ -293,5 +293,3 @@ D TIANBO HJR-4102-L, Single Pole Relay, 5mm Pitch, 3A
 K Single Pole Relay
 F https://cdn-reichelt.de/documents/datenblatt/C300/DS_HJR4102E.pdf
 $ENDCMP
-#
-#End Doc Library

--- a/library/relays.lib
+++ b/library/relays.lib
@@ -328,11 +328,13 @@ ENDDEF
 #
 # G5Q-1
 #
-DEF G5Q-1 RL 0 40 Y Y 1 F N
-F0 "RL" 650 350 50 H V L CNN
+DEF G5Q-1 K 0 40 Y Y 1 F N
+F0 "K" 650 350 50 H V L CNN
 F1 "G5Q-1" 650 250 50 H V L CNN
 F2 "Relays_THT:Relay_SPDT_OMRON-G5Q" 650 150 50 H I L CNN
-F3 "" 200 -200 50 H V C CNN
+F3 "https://www.omron.com/ecb/products/pdf/en-g5q.pdf" 650 -150 50 H I L CNN
+F4 "OMRON G5Q-1 Miniature Single Pole Relay, SPDT, 10A" 650 -50 60 H I L CNN "Description"
+F5 "Miniature Single Pole Relay" 650 50 60 H I L CNN "Keywords"
 $FPLIST
  Relay?SPDT?OMRON?G5Q*
 $ENDFPLIST
@@ -364,11 +366,13 @@ ENDDEF
 #
 # G5Q-1A
 #
-DEF G5Q-1A RL 0 40 Y Y 1 F N
-F0 "RL" 550 350 50 H V L CNN
+DEF G5Q-1A K 0 40 Y Y 1 F N
+F0 "K" 550 350 50 H V L CNN
 F1 "G5Q-1A" 550 250 50 H V L CNN
 F2 "Relays_THT:Relay_SPST-NO_OMRON-G5Q" 550 150 50 H I L CNN
-F3 "" 200 600 50 H V C CNN
+F3 "https://www.omron.com/ecb/products/pdf/en-g5q.pdf" 1100 -300 50 H I C CNN
+F4 "Miniature Single Pole Relay" 650 -400 60 H I C CNN "Keywords"
+F5 "G5G-1A, Miniature Single Pole Relay, SPST-NO, 10A" 1250 -200 60 H I C CNN "Description"
 $FPLIST
  Relay?SPST?NO?OMRON?G5Q*
 $ENDFPLIST

--- a/library/relays.lib
+++ b/library/relays.lib
@@ -1,3 +1,4 @@
+
 EESchema-LIBRARY Version 2.3
 #encoding utf-8
 #
@@ -332,9 +333,7 @@ DEF G5Q-1 K 0 40 Y Y 1 F N
 F0 "K" 650 350 50 H V L CNN
 F1 "G5Q-1" 650 250 50 H V L CNN
 F2 "Relays_THT:Relay_SPDT_OMRON-G5Q" 650 150 50 H I L CNN
-F3 "https://www.omron.com/ecb/products/pdf/en-g5q.pdf" 650 -150 50 H I L CNN
-F4 "OMRON G5Q-1 Miniature Single Pole Relay, SPDT, 10A" 650 -50 60 H I L CNN "Description"
-F5 "Miniature Single Pole Relay" 650 50 60 H I L CNN "Keywords"
+F3 "" 650 -150 50 H I L CNN
 $FPLIST
  Relay?SPDT?OMRON?G5Q*
 $ENDFPLIST
@@ -370,9 +369,7 @@ DEF G5Q-1A K 0 40 Y Y 1 F N
 F0 "K" 550 350 50 H V L CNN
 F1 "G5Q-1A" 550 250 50 H V L CNN
 F2 "Relays_THT:Relay_SPST-NO_OMRON-G5Q" 550 150 50 H I L CNN
-F3 "https://www.omron.com/ecb/products/pdf/en-g5q.pdf" 1100 -300 50 H I C CNN
-F4 "Miniature Single Pole Relay" 650 -400 60 H I C CNN "Keywords"
-F5 "G5G-1A, Miniature Single Pole Relay, SPST-NO, 10A" 1250 -200 60 H I C CNN "Description"
+F3 "" 1100 -300 50 H I C CNN
 $FPLIST
  Relay?SPST?NO?OMRON?G5Q*
 $ENDFPLIST
@@ -646,5 +643,3 @@ X ~ 8 -200 -300 100 U 50 50 1 1 P
 X ~ 12 200 -300 100 U 50 50 1 1 P
 ENDDRAW
 ENDDEF
-#
-#End Library


### PR DESCRIPTION
Added description, datasheet, and keywords. Changed reference designator
from "RL" to IEEE standard "K".
