### PR TITLE
fixed 'ananlog' in cmos 4066

### DIFF
--- a/library/cmos4000.dcm
+++ b/library/cmos4000.dcm
@@ -45,6 +45,7 @@ $ENDCMP
 $CMP 4016
 D Quad Analog Switches
 K CMOS SWITCH
+F http://www.ti.com/lit/ds/symlink/cd4016b.pdf
 $ENDCMP
 #
 $CMP 4017
@@ -125,8 +126,9 @@ K CMOS MUX MUX2
 $ENDCMP
 #
 $CMP 4066
-D Quad Ananlog Switches
+D Quad Analog Switches
 K CMOS SWITCH
+F http://www.ti.com/lit/ds/symlink/cd4066b.pdf
 $ENDCMP
 #
 $CMP 4069


### PR DESCRIPTION
Fix 'ananlog' spelling mistake in CMOS 4066; added links to datasheets for CMOS 4016, 4066