### PR TITLE
remove number of positions from terminal block footprint filter

### DIFF
--- a/library/conn.lib
+++ b/library/conn.lib
@@ -11654,7 +11654,7 @@ F1 "Screw_Terminal_1x01" -150 0 50 V V C TNN
 F2 "" 0 -125 50 H I C CNN
 F3 "" 0 -100 50 H I C CNN
 $FPLIST
- TerminalBlock*1pol
+ TerminalBlock*
 $ENDFPLIST
 DRAW
 C 25 0 50 0 1 10 N
@@ -11673,8 +11673,8 @@ F1 "Screw_Terminal_1x02" -150 0 50 V V C TNN
 F2 "" 0 -225 50 H I C CNN
 F3 "" -25 0 50 H I C CNN
 $FPLIST
- bornier2
- TerminalBlock*2pol
+ bornier*
+ TerminalBlock*
 $ENDFPLIST
 DRAW
 C 25 -100 50 0 1 10 N
@@ -11697,8 +11697,8 @@ F1 "Screw_Terminal_1x03" -150 0 50 V V C TNN
 F2 "" 0 -325 50 H I C CNN
 F3 "" -25 100 50 H I C CNN
 $FPLIST
- bornier3
- TerminalBlock*3pol
+ bornier*
+ TerminalBlock*
 $ENDFPLIST
 DRAW
 C 25 -200 50 0 1 10 N
@@ -11725,8 +11725,8 @@ F1 "Screw_Terminal_1x04" -150 0 50 V V C TNN
 F2 "" 0 -425 50 H I C CNN
 F3 "" -25 200 50 H I C CNN
 $FPLIST
- bornier4
- TerminalBlock*4pol
+ bornier*
+ TerminalBlock*
 $ENDFPLIST
 DRAW
 C 25 -300 50 0 1 10 N
@@ -11757,8 +11757,8 @@ F1 "Screw_Terminal_1x05" -150 0 50 V V C TNN
 F2 "" 0 -525 50 H I C CNN
 F3 "" -25 300 50 H I C CNN
 $FPLIST
- bornier5
- TerminalBlock*5pol
+ bornier*
+ TerminalBlock*
 $ENDFPLIST
 DRAW
 C 25 -400 50 0 1 10 N
@@ -11793,8 +11793,8 @@ F1 "Screw_Terminal_1x06" -150 0 50 V V C TNN
 F2 "" 0 -625 50 H I C CNN
 F3 "" -25 400 50 H I C CNN
 $FPLIST
- bornier6
- TerminalBlock*6pol
+ bornier*
+ TerminalBlock*
 $ENDFPLIST
 DRAW
 C 25 -500 50 0 1 10 N
@@ -11833,7 +11833,7 @@ F1 "Screw_Terminal_1x07" -150 0 50 V V C TNN
 F2 "" 0 -725 50 H I C CNN
 F3 "" -25 500 50 H I C CNN
 $FPLIST
- TerminalBlock*7pol
+ TerminalBlock*
 $ENDFPLIST
 DRAW
 C 25 -600 50 0 1 10 N
@@ -11876,7 +11876,7 @@ F1 "Screw_Terminal_1x08" -150 0 50 V V C TNN
 F2 "" 0 -825 50 H I C CNN
 F3 "" -25 600 50 H I C CNN
 $FPLIST
- TerminalBlock*8pol
+ TerminalBlock*
 $ENDFPLIST
 DRAW
 C 25 -700 50 0 1 10 N
@@ -11923,7 +11923,7 @@ F1 "Screw_Terminal_1x09" -150 0 50 V V C TNN
 F2 "" 0 -925 50 H I C CNN
 F3 "" -25 700 50 H I C CNN
 $FPLIST
- TerminalBlock*9pol
+ TerminalBlock*
 $ENDFPLIST
 DRAW
 C 25 -800 50 0 1 10 N
@@ -11974,7 +11974,7 @@ F1 "Screw_Terminal_1x10" -150 0 50 V V C TNN
 F2 "" 0 -1025 50 H I C CNN
 F3 "" -25 800 50 H I C CNN
 $FPLIST
- TerminalBlock*10pol
+ TerminalBlock*
 $ENDFPLIST
 DRAW
 C 25 -900 50 0 1 10 N
@@ -12029,7 +12029,7 @@ F1 "Screw_Terminal_1x11" -150 0 50 V V C TNN
 F2 "" 0 -1125 50 H I C CNN
 F3 "" -25 900 50 H I C CNN
 $FPLIST
- TerminalBlock*11pol
+ TerminalBlock*
 $ENDFPLIST
 DRAW
 C 25 -1000 50 0 1 10 N
@@ -12088,7 +12088,7 @@ F1 "Screw_Terminal_1x12" -150 0 50 V V C TNN
 F2 "" 0 -1225 50 H I C CNN
 F3 "" -25 1000 50 H I C CNN
 $FPLIST
- TerminalBlock*12pol
+ TerminalBlock*
 $ENDFPLIST
 DRAW
 C 25 -1100 50 0 1 10 N


### PR DESCRIPTION
According to rule 4.12.iii, "Filters should not match the pin count."

Also, filtering for 2pol, 3pol, etc. causes the filter to miss the newly added footprints that use a [different naming convention](https://github.com/KiCad/Connectors_Terminal_Blocks.pretty/pull/11) (e. g. `TerminalBlock_Philmore_TB132_02x5mm_Straight`).