### PR TITLE
Several adjustable regulators had "fixed" as a keyword, or vice-versa.

### DIFF
--- a/library/regul.dcm
+++ b/library/regul.dcm
@@ -134,13 +134,13 @@ $ENDCMP
 #
 $CMP AP2204K-ADJ
 D 150mA low dropout adjustable linear regulator, wide input voltage range, SOT-23-5 package
-K linear regulator ldo fixed positive
+K linear regulator ldo adjustable positive
 F https://www.diodes.com/assets/Datasheets/AP2204.pdf
 $ENDCMP
 #
 $CMP AP2204MP-ADJ
 D 150mA low dropout adjustable linear regulator, wide input voltage range, PSOP-8 package
-K linear regulator ldo fixed positive
+K linear regulator ldo adjustable positive
 F https://www.diodes.com/assets/Datasheets/AP2204.pdf
 $ENDCMP
 #
@@ -1808,7 +1808,7 @@ $ENDCMP
 #
 $CMP LM1085-3.3
 D 3A 27V Linear Regulator, Fixed Output 3.3V, TO-220/TO-263
-K Voltage Regulator Adjustable 5A Positive
+K Voltage Regulator Fixed 5A Positive
 F http://www.ti.com/lit/ds/symlink/lm1085.pdf
 $ENDCMP
 #
@@ -2750,7 +2750,7 @@ $ENDCMP
 #
 $CMP LT1584-ADJ
 D Positive 7A 35V Low Dropout Fast Response Linear Regulator, Adjustable Output, TO-220
-K Voltage Regulator 7A Positive Fixed
+K Voltage Regulator 7A Positive Adjustable
 F http://cds.linear.com/docs/en/datasheet/158457a.pdf
 $ENDCMP
 #
@@ -2780,7 +2780,7 @@ $ENDCMP
 #
 $CMP LT1585-ADJ
 D Positive 4.6A 35V Low Dropout Fast Response Linear Regulator, Adjustable Output, TO-220/TO-263
-K Voltage Regulator 4.6A Positive Fixed
+K Voltage Regulator 4.6A Positive Adjustable
 F http://cds.linear.com/docs/en/datasheet/158457a.pdf
 $ENDCMP
 #
@@ -2804,7 +2804,7 @@ $ENDCMP
 #
 $CMP LT1587-ADJ
 D Positive 3A 35V Low Dropout Fast Response Linear Regulator, Adjustable Output, TO-220/TO-263
-K Voltage Regulator 3A Positive Adjsutable
+K Voltage Regulator 3A Positive Adjustable
 F http://cds.linear.com/docs/en/datasheet/158457a.pdf
 $ENDCMP
 #


### PR DESCRIPTION
I just noticed that in `regul.dcm`, several adjustable regulators had "fixed" as a keyword, or vice-versa.  This PR corrects that.