### PR TITLE
Ignore pretty folders inside the modules containter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.bak
 *.bck
 internat/
+modules/*.pretty/


### PR DESCRIPTION
This is a proposal.

I use KiCad master as my library. I also let KiCad download the footprints to that folder. This commits ignores the `.pretty` folders inside modules allowing me to commit small changes in the libraries without all the footprints cluttering git output.