### PR TITLE
Fix decription for Q_Photo_NPN_EC.

### DIFF
--- a/library/device.dcm
+++ b/library/device.dcm
@@ -1274,7 +1274,7 @@ K npn phototransistor
 $ENDCMP
 #
 $CMP Q_Photo_NPN_EC
-D Phototransistor NPN, 2-pin (C=1, E=2)
+D Phototransistor NPN, 2-pin (E=1, C=2)
 K NPN phototransistor
 $ENDCMP
 #


### PR DESCRIPTION
`Q_Photo_NPN_EC` had the description "Phototransistor NPN, 2-pin (C=1, E=2)".  I think it should be the other way around.