### PR TITLE
MCU_ST_STM32: Correct descriptions of STM32F446Zxx

### DIFF
--- a/library/MCU_ST_STM32.dcm
+++ b/library/MCU_ST_STM32.dcm
@@ -2839,19 +2839,19 @@ F http://www.st.com/st-web-ui/static/active/en/resource/technical/document/datas
 $ENDCMP
 #
 $CMP STM32F446ZCTx
-D Core: ARM Cortex-M4 Package: LQFP144 Flash: 256KB Ram: 128KB Frequency: 180MHz Voltage: 1.7..3.6V IO-pins: 114
+D Core: ARM Cortex-M4 Package: LQFP144 Flash: 256kB RAM: 128kB Frequency: 180MHz Voltage: 1.7..3.6V IO-pins: 114
 K ARM Cortex-M4 STM32F4 STM32F446
 F http://www.st.com/st-web-ui/static/active/en/resource/technical/document/datasheet/DM00141306.pdf
 $ENDCMP
 #
 $CMP STM32F446ZETx
-D Core: ARM Cortex-M4 Package: LQFP144 Flash: 256KB Ram: 128KB Frequency: 180MHz Voltage: 1.7..3.6V IO-pins: 114
+D Core: ARM Cortex-M4 Package: LQFP144 Flash: 512kB RAM: 128kB Frequency: 180MHz Voltage: 1.7..3.6V IO-pins: 114
 K ARM Cortex-M4 STM32F4 STM32F446
 F http://www.st.com/st-web-ui/static/active/en/resource/technical/document/datasheet/DM00141306.pdf
 $ENDCMP
 #
 $CMP STM32F446ZEHx
-D Core: ARM Cortex-M4 Package: UFBGA144 Flash: 512KB Ram: 128KB Frequency: 180MHz Voltage: 1.7..3.6V IO-pins: 114
+D Core: ARM Cortex-M4 Package: UFBGA144 Flash: 512kB RAM: 128kB Frequency: 180MHz Voltage: 1.7..3.6V IO-pins: 114
 K ARM Cortex-M4 STM32F4 STM32F446
 F http://www.st.com/st-web-ui/static/active/en/resource/technical/document/datasheet/DM00141306.pdf
 $ENDCMP


### PR DESCRIPTION
I'd change the rest of the descriptions in this manner (without checking MCU parameter correctness, as in this case). Or even further, e.g.:
Core: ARM Cortex-M4, Package: LQFP144, Flash: 256 kB, RAM: 128 kB, Frequency: 180 MHz, Voltage: 1.7..3.6V, I/O-pins: 114
Rationale: "KB" - Kelvin times something vs.  "kB" - kilobyte, "Ram" - a male sheep vs. "RAM" - Random Access Memory.
Is there any policy on this?