### PR TITLE
Fixed metadata error

### DIFF
--- a/library/wiznet.dcm
+++ b/library/wiznet.dcm
@@ -1,8 +1,8 @@
 EESchema-DOCLIB  Version 2.0
 #
 $CMP W5100
-D WizNet W5100  10/100Mb Ethernet controller with TCP/IP stack
-K Wiznet Ethernet controller 
+D 10/100Mb Ethernet controller with TCP/IP stack, LQFP-80
+K Wiznet Ethernet controller
 F https://www.sparkfun.com/datasheets/DevTools/Arduino/W5100_Datasheet_v1_1_6.pdf
 $ENDCMP
 #


### PR DESCRIPTION

Got some time over and removed a metadata error in wiznet.lib 
(The symbol name was included in the description)

