### PR TITLE
Adjust symbol names to the new KLC

### DIFF
--- a/library/adc-dac.dcm
+++ b/library/adc-dac.dcm
@@ -44,13 +44,13 @@ $ENDCMP
 #
 $CMP AD5687BCPZ
 D Dual, 12-Bit nanoDAC+ with SPI Interface, LFCSP-16
-K dac 2nch 12bit spi 
+K dac 2nch 12bit spi
 F http://www.analog.com/media/en/technical-documentation/data-sheets/AD5689_5687.pdf
 $ENDCMP
 #
 $CMP AD5687BRUZ
 D Dual, 12-Bit nanoDAC+ with SPI Interface, TSSOP-16
-K dac 2nch 12bit spi 
+K dac 2nch 12bit spi
 F http://www.analog.com/media/en/technical-documentation/data-sheets/AD5689_5687.pdf
 $ENDCMP
 #
@@ -462,7 +462,7 @@ K Single-supply, 12bit, 4 ch, touch screen driver, 2.2 - 5.25 VDD, -40 to +85 C,
 F http://www.ti.com/lit/ds/symlink/ads7843.pdf
 $ENDCMP
 #
-$CMP ADS7843E/2K5
+$CMP ADS7843E-2K5
 D Single-supply, 12bit, 4 ch, touch screen driver, 2.2 - 5.25 VDD, -40 to +85 C, QSPI, SPI, 3-wire serial interface, SSOP-16
 K Single-supply, 12bit, 4 ch, touch screen driver, 2.2 - 5.25 VDD, -40 to +85 C, QSPI, SPI, 3-wire serial interface, SSOP-16
 F http://www.ti.com/lit/ds/symlink/ads7843.pdf
@@ -797,25 +797,25 @@ K 18-Bit ADC I2C IIC I²C Delta-Sigma-ADC Delta-Sigma-ADC Reference 4ch
 F http://ww1.microchip.com/downloads/en/DeviceDoc/22088c.pdf
 $ENDCMP
 #
-$CMP MCP3425A0T-E/CH
+$CMP MCP3425A0T-ECH
 D Single Delta-Sigma 16bit Analog to Digital Converter, I2C Interface, SOT-23-6
 K Sigma-Delta ADC Converter 16bit I2C  1ch
 F http://ww1.microchip.com/downloads/en/DeviceDoc/22072b.pdf
 $ENDCMP
 #
-$CMP MCP3425A1T-E/CH
+$CMP MCP3425A1T-ECH
 D Single Delta-Sigma 16bit Analog to Digital Converter, I2C Interface, SOT-23-6
 K Sigma-Delta ADC Converter 16bit I2C 1ch
 F http://ww1.microchip.com/downloads/en/DeviceDoc/22072b.pdf
 $ENDCMP
 #
-$CMP MCP3425A2T-E/CH
+$CMP MCP3425A2T-ECH
 D Single Delta-Sigma 16bit Analog to Digital Converter, I2C Interface, SOT-23-6
 K Sigma-Delta ADC Converter 16bit I2C 1ch
 F http://ww1.microchip.com/downloads/en/DeviceDoc/22072b.pdf
 $ENDCMP
 #
-$CMP MCP3425A3T-E/CH
+$CMP MCP3425A3T-ECH
 D Single Delta-Sigma 16bit Analog to Digital Converter, I2C Interface, SOT-23-6
 K Sigma-Delta ADC Converter 16bit I2C 1ch
 F http://ww1.microchip.com/downloads/en/DeviceDoc/22072b.pdf
@@ -857,25 +857,25 @@ K adc 4ch 16bit i2c
 F http://ww1.microchip.com/downloads/en/DeviceDoc/22226a.pdf
 $ENDCMP
 #
-$CMP MCP3550-50-E/MS
+$CMP MCP3550-50-EMS
 D Single Delta-Sigma 22bit Analog to Digital Converter, SPI Interface, 50Hz Rejection, MSOP-8
 K Sigma-Delta ADC Converter 22bit SPI 1ch
 F http://ww1.microchip.com/downloads/en/devicedoc/21950c.pdf
 $ENDCMP
 #
-$CMP MCP3550-60-E/SN
+$CMP MCP3550-60-ESN
 D Single Delta-Sigma 22bit Analog to Digital Converter, SPI Interface, 60Hz Rejection, MSOP-8
 K Sigma-Delta ADC Converter 22bit SPI 1ch
 F http://ww1.microchip.com/downloads/en/devicedoc/21950c.pdf
 $ENDCMP
 #
-$CMP MCP3551-E/MS
+$CMP MCP3551-EMS
 D Single Delta-Sigma 22bit Analog to Digital Converter, SPI Interface, MSOP-8
 K Sigma-Delta ADC Converter 22bit SPI 1ch
 F http://ww1.microchip.com/downloads/en/devicedoc/21950c.pdf
 $ENDCMP
 #
-$CMP MCP3553-E/SN
+$CMP MCP3553-ESN
 D Single Delta-Sigma 22bit Analog to Digital Converter, SPI Interface, MSOP-8
 K Sigma-Delta ADC Converter 22bit SPI 1ch
 F http://ww1.microchip.com/downloads/en/devicedoc/21950c.pdf
@@ -893,7 +893,7 @@ K 8-Bit DAC SPI Reference 1ch
 F http://ww1.microchip.com/downloads/en/DeviceDoc/22244B.pdf
 $ENDCMP
 #
-$CMP MCP4801-E/MC
+$CMP MCP4801-EMC
 D 8-Bit D/A Converters with SPI Interface, internal Reference (2.048V)
 K 8-Bit DAC SPI Reference 1ch
 F http://ww1.microchip.com/downloads/en/DeviceDoc/22244B.pdf
@@ -911,7 +911,7 @@ K 10-Bit DAC SPI Reference 1ch
 F http://ww1.microchip.com/downloads/en/DeviceDoc/22244B.pdf
 $ENDCMP
 #
-$CMP MCP4811-E/MC
+$CMP MCP4811-EMC
 D 10-Bit D/A Converters with SPI Interface, internal Reference (2.048V)
 K 10-Bit DAC SPI Reference 1ch
 F http://ww1.microchip.com/downloads/en/DeviceDoc/22244B.pdf
@@ -929,7 +929,7 @@ K 12-Bit DAC SPI Reference 1ch
 F http://ww1.microchip.com/downloads/en/DeviceDoc/22244B.pdf
 $ENDCMP
 #
-$CMP MCP4821-E/MC
+$CMP MCP4821-EMC
 D 12-Bit D/A Converters with SPI Interface, internal Reference (2.048V)
 K 12-Bit DAC SPI Reference 1ch
 F http://ww1.microchip.com/downloads/en/DeviceDoc/22244B.pdf
@@ -947,7 +947,7 @@ K 8-Bit DAC SPI  1ch
 F http://ww1.microchip.com/downloads/en/DeviceDoc/22248a.pdf
 $ENDCMP
 #
-$CMP MCP4901-E/MC
+$CMP MCP4901-EMC
 D 8-Bit D/A Converters with SPI Interface
 K 8-Bit DAC SPI  1ch
 F http://ww1.microchip.com/downloads/en/DeviceDoc/22248a.pdf
@@ -965,7 +965,7 @@ K 10-Bit DAC SPI 1ch
 F http://ww1.microchip.com/downloads/en/DeviceDoc/22248a.pdf
 $ENDCMP
 #
-$CMP MCP4911-E/MC
+$CMP MCP4911-EMC
 D 10-Bit D/A Converters with SPI Interface
 K 10-Bit DAC SPI  1ch
 F http://ww1.microchip.com/downloads/en/DeviceDoc/22248a.pdf
@@ -983,25 +983,25 @@ K 12-Bit DAC SPI 1ch
 F http://ww1.microchip.com/downloads/en/DeviceDoc/22248a.pdf
 $ENDCMP
 #
-$CMP MCP4921-E/MC
+$CMP MCP4921-EMC
 D 12-Bit D/A Converters with SPI Interface
 K 12-Bit DAC SPI  1ch
 F http://ww1.microchip.com/downloads/en/DeviceDoc/22248a.pdf
 $ENDCMP
 #
-$CMP MCP4921-E/MS
+$CMP MCP4921-EMS
 D Single 12-bit Digital to Analog Converter, SPI Interface, MSOP-8
 K Single DAC 1ch 12bit SPI
 F http://ww1.microchip.com/downloads/en/devicedoc/21897a.pdf
 $ENDCMP
 #
-$CMP MCP4921-E/P
+$CMP MCP4921-EP
 D Single 12-bit Digital to Analog Converter, SPI Interface, PDIP-8
 K Single DAC 1ch 12bit SPI
 F http://ww1.microchip.com/downloads/en/devicedoc/21897a.pdf
 $ENDCMP
 #
-$CMP MCP4921-E/SN
+$CMP MCP4921-ESN
 D Single 12-bit Digital to Analog Converter, SPI Interface, SOIC-8
 K Single DAC 1ch 12bit SPI
 F http://ww1.microchip.com/downloads/en/devicedoc/21897a.pdf
@@ -1013,19 +1013,19 @@ K 12-Bit DAC SPI 2CH
 F http://ww1.microchip.com/downloads/en/DeviceDoc/22250A.pdf
 $ENDCMP
 #
-$CMP MCP4922-E/P
+$CMP MCP4922-EP
 D Dual 12-bit Digital to Analog Converter, SPI Interface, PDIP-14
 K Dual DAC 1ch 12bit SPI
 F http://ww1.microchip.com/downloads/en/devicedoc/21897a.pdf
 $ENDCMP
 #
-$CMP MCP4922-E/SL
+$CMP MCP4922-ESL
 D Dual 12-bit Digital to Analog Converter, SPI Interface, SOIC-14
 K Dual DAC 1ch 12bit SPI
 F http://ww1.microchip.com/downloads/en/devicedoc/21897a.pdf
 $ENDCMP
 #
-$CMP MCP4922-E/ST
+$CMP MCP4922-EST
 D Dual 12-bit Digital to Analog Converter, SPI Interface, TSSOP-14
 K Dual DAC 1ch 12bit SPI
 F http://ww1.microchip.com/downloads/en/devicedoc/21897a.pdf


### PR DESCRIPTION
Some symbols with an "/" in their names get their names adjusted to the new KLC.