### PR TITLE
Clearing an error in STM32L071/STM32L072 loading libs

### DIFF
--- a/library/MCU_ST_STM32.dcm
+++ b/library/MCU_ST_STM32.dcm
@@ -3558,23 +3558,11 @@ K ARM Cortex-M0+ STM32L0 STM32L0x1
 F http://www.st.com/st-web-ui/static/active/en/resource/technical/document/datasheet/DM00141136.pdf
 $ENDCMP
 #
-#$CMP STM32L071 kBTx
-#D Core: ARM Cortex-M0+, Package: LQFP32, Flash: 128 kB, RAM: 20 kB, Frequency: 32 MHz, Voltage: 1.65..3.6V, I/O pins: 25
-#K ARM Cortex-M0+ STM32L0 STM32L0x1
-#F http://www.st.com/st-web-ui/static/active/en/resource/technical/document/datasheet/DM00141136.pdf
-#$ENDCMP
-#
 $CMP STM32L071KZTx
 D Core: ARM Cortex-M0+, Package: LQFP32, Flash: 128 kB, RAM: 20 kB, Frequency: 32 MHz, Voltage: 1.65..3.6V, I/O pins: 25
 K ARM Cortex-M0+ STM32L0 STM32L0x1
 F http://www.st.com/st-web-ui/static/active/en/resource/technical/document/datasheet/DM00141136.pdf
 $ENDCMP
-#
-#$CMP STM32L071 kBUx
-#D Core: ARM Cortex-M0+, Package: UFQFPN32, Flash: 128 kB, RAM: 20 kB, Frequency: 32 MHz, Voltage: 1.65..3.6V, I/O pins: 23
-#K ARM Cortex-M0+ STM32L0 STM32L0x1
-#F http://www.st.com/st-web-ui/static/active/en/resource/technical/document/datasheet/DM00141136.pdf
-#$ENDCMP
 #
 $CMP STM32L071KZUx
 D Core: ARM Cortex-M0+, Package: UFQFPN32, Flash: 128 kB, RAM: 20 kB, Frequency: 32 MHz, Voltage: 1.65..3.6V, I/O pins: 23
@@ -3672,23 +3660,11 @@ K ARM Cortex-M0+ STM32L0 STM32L0x2
 F http://www.st.com/st-web-ui/static/active/en/resource/technical/document/datasheet/DM00141133.pdf
 $ENDCMP
 #
-#$CMP STM32L072 kBTx
-#D Core: ARM Cortex-M0+, Package: LQFP32, Flash: 128 kB, RAM: 20 kB, Frequency: 32 MHz, Voltage: 1.65..--V, I/O pins: 25
-#K ARM Cortex-M0+ STM32L0 STM32L0x2
-#F http://www.st.com/st-web-ui/static/active/en/resource/technical/document/datasheet/DM00141133.pdf
-#$ENDCMP
-#
 $CMP STM32L072KZTx
 D Core: ARM Cortex-M0+, Package: LQFP32, Flash: 128 kB, RAM: 20 kB, Frequency: 32 MHz, Voltage: 1.65..--V, I/O pins: 25
 K ARM Cortex-M0+ STM32L0 STM32L0x2
 F http://www.st.com/st-web-ui/static/active/en/resource/technical/document/datasheet/DM00141133.pdf
 $ENDCMP
-#
-#$CMP STM32L072 kBUx
-#D Core: ARM Cortex-M0+, Package: UFQFPN32, Flash: 128 kB, RAM: 20 kB, Frequency: 32 MHz, Voltage: 1.65..--V, I/O pins: 23
-#K ARM Cortex-M0+ STM32L0 STM32L0x2
-#F http://www.st.com/st-web-ui/static/active/en/resource/technical/document/datasheet/DM00141133.pdf
-#$ENDCMP
 #
 $CMP STM32L072KZUx
 D Core: ARM Cortex-M0+, Package: UFQFPN32, Flash: 128 kB, RAM: 20 kB, Frequency: 32 MHz, Voltage: 1.65..--V, I/O pins: 23

--- a/library/MCU_ST_STM32.dcm
+++ b/library/MCU_ST_STM32.dcm
@@ -3558,11 +3558,11 @@ K ARM Cortex-M0+ STM32L0 STM32L0x1
 F http://www.st.com/st-web-ui/static/active/en/resource/technical/document/datasheet/DM00141136.pdf
 $ENDCMP
 #
-$CMP STM32L071 kBTx
-D Core: ARM Cortex-M0+, Package: LQFP32, Flash: 128 kB, RAM: 20 kB, Frequency: 32 MHz, Voltage: 1.65..3.6V, I/O pins: 25
-K ARM Cortex-M0+ STM32L0 STM32L0x1
-F http://www.st.com/st-web-ui/static/active/en/resource/technical/document/datasheet/DM00141136.pdf
-$ENDCMP
+#$CMP STM32L071 kBTx
+#D Core: ARM Cortex-M0+, Package: LQFP32, Flash: 128 kB, RAM: 20 kB, Frequency: 32 MHz, Voltage: 1.65..3.6V, I/O pins: 25
+#K ARM Cortex-M0+ STM32L0 STM32L0x1
+#F http://www.st.com/st-web-ui/static/active/en/resource/technical/document/datasheet/DM00141136.pdf
+#$ENDCMP
 #
 $CMP STM32L071KZTx
 D Core: ARM Cortex-M0+, Package: LQFP32, Flash: 128 kB, RAM: 20 kB, Frequency: 32 MHz, Voltage: 1.65..3.6V, I/O pins: 25
@@ -3570,11 +3570,11 @@ K ARM Cortex-M0+ STM32L0 STM32L0x1
 F http://www.st.com/st-web-ui/static/active/en/resource/technical/document/datasheet/DM00141136.pdf
 $ENDCMP
 #
-$CMP STM32L071 kBUx
-D Core: ARM Cortex-M0+, Package: UFQFPN32, Flash: 128 kB, RAM: 20 kB, Frequency: 32 MHz, Voltage: 1.65..3.6V, I/O pins: 23
-K ARM Cortex-M0+ STM32L0 STM32L0x1
-F http://www.st.com/st-web-ui/static/active/en/resource/technical/document/datasheet/DM00141136.pdf
-$ENDCMP
+#$CMP STM32L071 kBUx
+#D Core: ARM Cortex-M0+, Package: UFQFPN32, Flash: 128 kB, RAM: 20 kB, Frequency: 32 MHz, Voltage: 1.65..3.6V, I/O pins: 23
+#K ARM Cortex-M0+ STM32L0 STM32L0x1
+#F http://www.st.com/st-web-ui/static/active/en/resource/technical/document/datasheet/DM00141136.pdf
+#$ENDCMP
 #
 $CMP STM32L071KZUx
 D Core: ARM Cortex-M0+, Package: UFQFPN32, Flash: 128 kB, RAM: 20 kB, Frequency: 32 MHz, Voltage: 1.65..3.6V, I/O pins: 23
@@ -3672,11 +3672,11 @@ K ARM Cortex-M0+ STM32L0 STM32L0x2
 F http://www.st.com/st-web-ui/static/active/en/resource/technical/document/datasheet/DM00141133.pdf
 $ENDCMP
 #
-$CMP STM32L072 kBTx
-D Core: ARM Cortex-M0+, Package: LQFP32, Flash: 128 kB, RAM: 20 kB, Frequency: 32 MHz, Voltage: 1.65..--V, I/O pins: 25
-K ARM Cortex-M0+ STM32L0 STM32L0x2
-F http://www.st.com/st-web-ui/static/active/en/resource/technical/document/datasheet/DM00141133.pdf
-$ENDCMP
+#$CMP STM32L072 kBTx
+#D Core: ARM Cortex-M0+, Package: LQFP32, Flash: 128 kB, RAM: 20 kB, Frequency: 32 MHz, Voltage: 1.65..--V, I/O pins: 25
+#K ARM Cortex-M0+ STM32L0 STM32L0x2
+#F http://www.st.com/st-web-ui/static/active/en/resource/technical/document/datasheet/DM00141133.pdf
+#$ENDCMP
 #
 $CMP STM32L072KZTx
 D Core: ARM Cortex-M0+, Package: LQFP32, Flash: 128 kB, RAM: 20 kB, Frequency: 32 MHz, Voltage: 1.65..--V, I/O pins: 25
@@ -3684,11 +3684,11 @@ K ARM Cortex-M0+ STM32L0 STM32L0x2
 F http://www.st.com/st-web-ui/static/active/en/resource/technical/document/datasheet/DM00141133.pdf
 $ENDCMP
 #
-$CMP STM32L072 kBUx
-D Core: ARM Cortex-M0+, Package: UFQFPN32, Flash: 128 kB, RAM: 20 kB, Frequency: 32 MHz, Voltage: 1.65..--V, I/O pins: 23
-K ARM Cortex-M0+ STM32L0 STM32L0x2
-F http://www.st.com/st-web-ui/static/active/en/resource/technical/document/datasheet/DM00141133.pdf
-$ENDCMP
+#$CMP STM32L072 kBUx
+#D Core: ARM Cortex-M0+, Package: UFQFPN32, Flash: 128 kB, RAM: 20 kB, Frequency: 32 MHz, Voltage: 1.65..--V, I/O pins: 23
+#K ARM Cortex-M0+ STM32L0 STM32L0x2
+#F http://www.st.com/st-web-ui/static/active/en/resource/technical/document/datasheet/DM00141133.pdf
+#$ENDCMP
 #
 $CMP STM32L072KZUx
 D Core: ARM Cortex-M0+, Package: UFQFPN32, Flash: 128 kB, RAM: 20 kB, Frequency: 32 MHz, Voltage: 1.65..--V, I/O pins: 23


### PR DESCRIPTION
I'm getting four error message when libraries are loaded when I go to select a library. I've been ignoring it for a few days but decided I'd take a look at it. There seems to be a problem in the MCU_ST_STM32.dcm library file. When I comment out four blocks I clear the error message. I'm not sure this is the correct solution, obviously it's just me having this problem so it may well be down to my configuration. The errors are:

19:45:31: Alias 'STM32L071' not found in library:

'/home/john/kicad/libs/kicad-library/library/MCU_ST_STM32.dcm'

at line 3561 offset 15
19:45:31: Alias 'STM32L071' not found in library:

'/home/john/kicad/libs/kicad-library/library/MCU_ST_STM32.dcm'

at line 3573 offset 15
19:45:31: Alias 'STM32L072' not found in library:

'/home/john/kicad/libs/kicad-library/library/MCU_ST_STM32.dcm'

at line 3675 offset 15
19:45:31: Alias 'STM32L072' not found in library:

'/home/john/kicad/libs/kicad-library/library/MCU_ST_STM32.dcm'

at line 3687 offset 15
