### PR TITLE
MCU_Texas_MSP430: update metadata

### DIFF
--- a/library/MCU_Texas_MSP430.dcm
+++ b/library/MCU_Texas_MSP430.dcm
@@ -1,2143 +1,2143 @@
 EESchema-DOCLIB  Version 2.0
 #
 $CMP MSP430AFE221IPW
-D 24pin TSSOP, 4KB Flash Memory, 256B RAM
+D 4kB Flash, 256B RAM, TSSOP-24
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430afe222.pdf
 $ENDCMP
 #
 $CMP MSP430AFE222IPW
-D 24pin TSSOP, 4KB Flash Memory, 256B RAM
+D 4kB Flash, 256B RAM, TSSOP-24
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430afe222.pdf
 $ENDCMP
 #
 $CMP MSP430AFE223IPW
-D 24pin TSSOP, 4KB Flash Memory, 256B RAM
+D 4kB Flash, 256B RAM, TSSOP-24
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430afe222.pdf
 $ENDCMP
 #
 $CMP MSP430AFE231IPW
-D 24pin TSSOP, 8KB Flash Memory, 512B RAM
+D 8kB Flash, 512B RAM, TSSOP-24
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430afe222.pdf
 $ENDCMP
 #
 $CMP MSP430AFE232IPW
-D 24pin TSSOP, 8KB Flash Memory, 512B RAM
+D 8kB Flash, 512B RAM, TSSOP-24
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430afe222.pdf
 $ENDCMP
 #
 $CMP MSP430AFE233IPW
-D 24pin TSSOP, 8KB Flash Memory, 512B RAM
+D 8kB Flash, 512B RAM, TSSOP-24
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430afe222.pdf
 $ENDCMP
 #
 $CMP MSP430AFE251IPW
-D 24pin TSSOP, 16KB Flash Memory, 512B RAM
+D 16kB Flash, 512B RAM, TSSOP-24
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430afe222.pdf
 $ENDCMP
 #
 $CMP MSP430AFE252IPW
-D 24pin TSSOP, 16KB Flash Memory, 512B RAM
+D 16kB Flash, 512B RAM, TSSOP-24
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430afe222.pdf
 $ENDCMP
 #
 $CMP MSP430AFE253IPW
-D 24pin TSSOP, 16KB Flash Memory, 512B RAM
+D 16kB Flash, 512B RAM, TSSOP-24
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430afe222.pdf
 $ENDCMP
 #
 $CMP MSP430F1101AIDGV
-D 20pin TVSOP, 1KB + 128B Flash Memory, 128B RAM
+D 1kB + 128B Flash, 128B RAM, TVSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1101a.pdf
 $ENDCMP
 #
 $CMP MSP430F1101AIDW
-D 20pin SOWB, 1KB + 128B Flash Memory, 128B RAM
+D 1kB + 128B Flash, 128B RAM, SOWB-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1101a.pdf
 $ENDCMP
 #
 $CMP MSP430F1101AIPW
-D 20pin TSSOP, 1KB + 128B Flash Memory, 128B RAM
+D 1kB + 128B Flash, 128B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1101a.pdf
 $ENDCMP
 #
 $CMP MSP430F1101AIRGE
-D 24pin QFN, 1KB + 128B Flash Memory, 128B RAM
+D 1kB + 128B Flash, 128B RAM, QFN-24
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1101a.pdf
 $ENDCMP
 #
 $CMP MSP430F1111AIDGV
-D 20pin TVSOP, 2KB + 256B Flash Memory, 128B RAM
+D 2kB + 256B Flash, 128B RAM, TVSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1101a.pdf
 $ENDCMP
 #
 $CMP MSP430F1111AIDW
-D 20pin SOWB, 2KB + 256B Flash Memory, 128B RAM
+D 2kB + 256B Flash, 128B RAM, SOWB-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1101a.pdf
 $ENDCMP
 #
 $CMP MSP430F1111AIPW
-D 20pin TSSOP, 2KB + 256B Flash Memory, 128B RAM
+D 2kB + 256B Flash, 128B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1101a.pdf
 $ENDCMP
 #
 $CMP MSP430F1111AIRGE
-D 24pin QFN, 2KB + 256B Flash Memory, 128B RAM
+D 2kB + 256B Flash, 128B RAM, QFN-24
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1101a.pdf
 $ENDCMP
 #
 $CMP MSP430F1121AIDGV
-D 20pin TVSOP, 4KB + 256B Flash Memory, 256B RAM
+D 4kB + 256B Flash, 256B RAM, TVSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1101a.pdf
 $ENDCMP
 #
 $CMP MSP430F1121AIDW
-D 20pin SOWB, 4KB + 256B Flash Memory, 256B RAM
+D 4kB + 256B Flash, 256B RAM, SOWB-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1101a.pdf
 $ENDCMP
 #
 $CMP MSP430F1121AIPW
-D 20pin TSSOP, 4KB + 256B Flash Memory, 256B RAM
+D 4kB + 256B Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1101a.pdf
 $ENDCMP
 #
 $CMP MSP430F1121AIRGE
-D 24pin QFN, 4KB + 256B Flash Memory, 256B RAM
+D 4kB + 256B Flash, 256B RAM, QFN-24
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1101a.pdf
 $ENDCMP
 #
 $CMP MSP430F1122IDW
-D 20pin SOWB, 4KB + 256B Flash Memory, 256B RAM
+D 4kB + 256B Flash, 256B RAM, SOWB-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1122.pdf
 $ENDCMP
 #
 $CMP MSP430F1122IPW
-D 20pin TSSOP, 4KB + 256B Flash Memory, 256B RAM
+D 4kB + 256B Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1122.pdf
 $ENDCMP
 #
 $CMP MSP430F1122IRHB
-D 32pin QFN, 4KB + 256B Flash Memory, 256B RAM
+D 4kB + 256B Flash, 256B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1122.pdf
 $ENDCMP
 #
 $CMP MSP430F1132IDW
-D 20pin SOWB, 8KB + 256B Flash Memory, 256B RAM
+D 8kB + 256B Flash, 256B RAM, SOWB-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1122.pdf
 $ENDCMP
 #
 $CMP MSP430F1132IPW
-D 20pin TSSOP, 8KB + 256B Flash Memory, 256B RAM
+D 8kB + 256B Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1122.pdf
 $ENDCMP
 #
 $CMP MSP430F1132IRHB
-D 32pin QFN, 8KB + 256B Flash Memory, 256B RAM
+D 8kB + 256B Flash, 256B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1122.pdf
 $ENDCMP
 #
 $CMP MSP430F1222IDW
-D 28pin SOWB, 4KB + 256B Flash Memory, 256B RAM
+D 4kB + 256B Flash, 256B RAM, SOWB-28
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1122.pdf
 $ENDCMP
 #
 $CMP MSP430F1222IPW
-D 28pin TSSOP, 4KB + 256B Flash Memory, 256B RAM
+D 4kB + 256B Flash, 256B RAM, TSSOP-28
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1122.pdf
 $ENDCMP
 #
 $CMP MSP430F1222IRHB
-D 32pin QFN, 4KB + 256B Flash Memory, 256B RAM
+D 4kB + 256B Flash, 256B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1122.pdf
 $ENDCMP
 #
 $CMP MSP430F122IDW
-D 28pin SOWB, 4KB + 256B Flash Memory, 256B RAM
+D 4kB + 256B Flash, 256B RAM, SOWB-28
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f122.pdf
 $ENDCMP
 #
 $CMP MSP430F122IPW
-D 28pin TSSOP, 4KB + 256B Flash Memory, 256B RAM
+D 4kB + 256B Flash, 256B RAM, TSSOP-28
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f122.pdf
 $ENDCMP
 #
 $CMP MSP430F122IRHB
-D 32pin QFN, 4KB + 256B Flash Memory, 256B RAM
+D 4kB + 256B Flash, 256B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1122.pdf
 $ENDCMP
 #
 $CMP MSP430F1232IDW
-D 28pin SOWB, 8KB + 256B Flash Memory, 256B RAM
+D 8kB + 256B Flash, 256B RAM, SOWB-28
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1122.pdf
 $ENDCMP
 #
 $CMP MSP430F1232IPW
-D 28pin TSSOP, 8KB + 256B Flash Memory, 256B RAM
+D 8kB + 256B Flash, 256B RAM, TSSOP-28
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1122.pdf
 $ENDCMP
 #
 $CMP MSP430F1232IRHB
-D 32pin QFN, 8KB + 256B Flash Memory, 256B RAM
+D 8kB + 256B Flash, 256B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1122.pdf
 $ENDCMP
 #
 $CMP MSP430F123IDW
-D 28pin SOWB, 8KB + 256B Flash Memory, 256B RAM
+D 8kB + 256B Flash, 256B RAM, SOWB-28
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f122.pdf
 $ENDCMP
 #
 $CMP MSP430F123IPW
-D 28pin TSSOP, 8KB + 256B Flash Memory, 256B RAM
+D 8kB + 256B Flash, 256B RAM, TSSOP-28
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f122.pdf
 $ENDCMP
 #
 $CMP MSP430F123IRHB
-D 32pin QFN, 8KB + 256B Flash Memory, 256B RAM
+D 8kB + 256B Flash, 256B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1122.pdf
 $ENDCMP
 #
 $CMP MSP430F2001IN
-D 14pin PDIP, 1KB + 256B Flash Memory, 128B RAM
+D 1kB + 256B Flash, 128B RAM, DIP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
 $ENDCMP
 #
 $CMP MSP430F2001IPW
-D 14pin TSSOP, 1KB + 256B Flash Memory, 128B RAM
+D 1kB + 256B Flash, 128B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
 $ENDCMP
 #
 $CMP MSP430F2001IRSA
-D 16pin QFN, 1KB + 256B Flash Memory, 128B RAM
+D 1kB + 256B Flash, 128B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
 $ENDCMP
 #
 $CMP MSP430F2002IN
-D 14pin PDIP, 1KB + 256B Flash Memory, 128B RAM
+D 1kB + 256B Flash, 128B RAM, DIP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
 $ENDCMP
 #
 $CMP MSP430F2002IPW
-D 14pin TSSOP, 1KB + 256B Flash Memory, 128B RAM
+D 1kB + 256B Flash, 128B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
 $ENDCMP
 #
 $CMP MSP430F2002IRSA
-D 16pin QFN, 1KB + 256B Flash Memory, 128B RAM
+D 1kB + 256B Flash, 128B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
 $ENDCMP
 #
 $CMP MSP430F2003IN
-D 14pin PDIP, 1KB + 256B Flash Memory, 128B RAM
+D 1kB + 256B Flash, 128B RAM, DIP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
 $ENDCMP
 #
 $CMP MSP430F2003IPW
-D 14pin TSSOP, 1KB + 256B Flash Memory, 128B RAM
+D 1kB + 256B Flash, 128B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
 $ENDCMP
 #
 $CMP MSP430F2003IRSA
-D 16pin QFN, 1KB + 256B Flash Memory, 128B RAM
+D 1kB + 256B Flash, 128B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
 $ENDCMP
 #
 $CMP MSP430F2011IN
-D 14pin PDIP, 2KB + 256B Flash Memory, 128B RAM
+D 2kB + 256B Flash, 128B RAM, DIP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
 $ENDCMP
 #
 $CMP MSP430F2011IPW
-D 14pin TSSOP, 2KB + 256B Flash Memory, 128B RAM
+D 2kB + 256B Flash, 128B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
 $ENDCMP
 #
 $CMP MSP430F2011IRSA
-D 16pin QFN, 2KB + 256B Flash Memory, 128B RAM
+D 2kB + 256B Flash, 128B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
 $ENDCMP
 #
 $CMP MSP430F2012IN
-D 14pin PDIP, 2KB + 256B Flash Memory, 128B RAM
+D 2kB + 256B Flash, 128B RAM, DIP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
 $ENDCMP
 #
 $CMP MSP430F2012IPW
-D 14pin TSSOP, 2KB + 256B Flash Memory, 128B RAM
+D 2kB + 256B Flash, 128B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
 $ENDCMP
 #
 $CMP MSP430F2012IRSA
-D 16pin QFN, 2KB + 256B Flash Memory, 128B RAM
+D 2kB + 256B Flash, 128B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
 $ENDCMP
 #
 $CMP MSP430F2013IN
-D 14pin PDIP, 2KB + 256B Flash Memory, 128B RAM
+D 2kB + 256B Flash, 128B RAM, DIP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
 $ENDCMP
 #
 $CMP MSP430F2013IPW
-D 14pin TSSOP, 2KB + 256B Flash Memory, 128B RAM
+D 2kB + 256B Flash, 128B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
 $ENDCMP
 #
 $CMP MSP430F2013IRSA
-D 16pin QFN, 2KB + 256B Flash Memory, 128B RAM
+D 2kB + 256B Flash, 128B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
 $ENDCMP
 #
 $CMP MSP430F2101IDGV
-D 20pin TVSOP, 1KB + 256B Flash Memory, 128B RAM
+D 1kB + 256B Flash, 128B RAM, TVSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
 $ENDCMP
 #
 $CMP MSP430F2101IDW
-D 20pin SOWB, 1KB + 256B Flash Memory, 128B RAM
+D 1kB + 256B Flash, 128B RAM, SOWB-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
 $ENDCMP
 #
 $CMP MSP430F2101IPW
-D 20pin TSSOP, 1KB + 256B Flash Memory, 128B RAM
+D 1kB + 256B Flash, 128B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
 $ENDCMP
 #
 $CMP MSP430F2101IRGE
-D 24pin QFN, 1KB + 256B Flash Memory, 128B RAM
+D 1kB + 256B Flash, 128B RAM, QFN-24
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
 $ENDCMP
 #
 $CMP MSP430F2111IDGV
-D 20pin TVSOP, 2KB + 256B Flash Memory, 128B RAM
+D 2kB + 256B Flash, 128B RAM, TVSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
 $ENDCMP
 #
 $CMP MSP430F2111IDW
-D 20pin SOWB, 2KB + 256B Flash Memory, 128B RAM
+D 2kB + 256B Flash, 128B RAM, SOWB-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
 $ENDCMP
 #
 $CMP MSP430F2111IPW
-D 20pin TSSOP, 2KB + 256B Flash Memory, 128B RAM
+D 2kB + 256B Flash, 128B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
 $ENDCMP
 #
 $CMP MSP430F2111IRGE
-D 24pin QFN, 2KB + 256B Flash Memory, 128B RAM
+D 2kB + 256B Flash, 128B RAM, QFN-24
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
 $ENDCMP
 #
 $CMP MSP430F2112IPW
-D 28pin TSSOP, 2KB + 256B Flash Memory, 256B RAM
+D 2kB + 256B Flash, 256B RAM, TSSOP-28
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2112.pdf
 $ENDCMP
 #
 $CMP MSP430F2112IRHB
-D 32pin QFN, 2KB + 256B Flash Memory, 256B RAM
+D 2kB + 256B Flash, 256B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2112.pdf
 $ENDCMP
 #
 $CMP MSP430F2112IRTV
-D 32pin QFN, 2KB + 256B Flash Memory, 256B RAM
+D 2kB + 256B Flash, 256B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2112.pdf
 $ENDCMP
 #
 $CMP MSP430F2121IDGV
-D 20pin TVSOP, 4KB + 256B Flash Memory, 256B RAM
+D 4kB + 256B Flash, 256B RAM, TVSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
 $ENDCMP
 #
 $CMP MSP430F2121IDW
-D 20pin SOWB, 4KB + 256B Flash Memory, 256B RAM
+D 4kB + 256B Flash, 256B RAM, SOWB-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
 $ENDCMP
 #
 $CMP MSP430F2121IPW
-D 20pin TSSOP, 4KB + 256B Flash Memory, 256B RAM
+D 4kB + 256B Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
 $ENDCMP
 #
 $CMP MSP430F2121IRGE
-D 24pin QFN, 4KB + 256B Flash Memory, 256B RAM
+D 4kB + 256B Flash, 256B RAM, QFN-24
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
 $ENDCMP
 #
 $CMP MSP430F2122IPW
-D 28pin TSSOP, 4KB + 256B Flash Memory, 512B RAM
+D 4kB + 256B Flash, 512B RAM, TSSOP-28
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2112.pdf
 $ENDCMP
 #
 $CMP MSP430F2122IRHB
-D 32pin QFN, 4KB + 256B Flash Memory, 512B RAM
+D 4kB + 256B Flash, 512B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2112.pdf
 $ENDCMP
 #
 $CMP MSP430F2122IRTV
-D 32pin QFN, 4KB + 256B Flash Memory, 512B RAM
+D 4kB + 256B Flash, 512B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2112.pdf
 $ENDCMP
 #
 $CMP MSP430F2131IDGV
-D 20pin TVSOP, 8KB + 256B Flash Memory, 256B RAM
+D 8kB + 256B Flash, 256B RAM, TVSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
 $ENDCMP
 #
 $CMP MSP430F2131IDW
-D 20pin SOWB, 8KB + 256B Flash Memory, 256B RAM
+D 8kB + 256B Flash, 256B RAM, SOWB-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
 $ENDCMP
 #
 $CMP MSP430F2131IPW
-D 20pin TSSOP, 8KB + 256B Flash Memory, 256B RAM
+D 8kB + 256B Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
 $ENDCMP
 #
 $CMP MSP430F2131IRGE
-D 24pin QFN, 8KB + 256B Flash Memory, 256B RAM
+D 8kB + 256B Flash, 256B RAM, QFN-24
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
 $ENDCMP
 #
 $CMP MSP430F2132IPW
-D 28pin TSSOP, 8KB + 256B Flash Memory, 512B RAM
+D 8kB + 256B Flash, 512B RAM, TSSOP-28
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2112.pdf
 $ENDCMP
 #
 $CMP MSP430F2132IRHB
-D 32pin QFN, 8KB + 256B Flash Memory, 512B RAM
+D 8kB + 256B Flash, 512B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2112.pdf
 $ENDCMP
 #
 $CMP MSP430F2132IRTV
-D 32pin QFN, 8KB + 256B Flash Memory, 512B RAM
+D 8kB + 256B Flash, 512B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2112.pdf
 $ENDCMP
 #
 $CMP MSP430F2232IDA
-D 38pin TSSOP, 8KB + 256B Flash Memory, 512B RAM
+D 8kB + 256B Flash, 512B RAM, TSSOP-38
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
 $ENDCMP
 #
 $CMP MSP430F2232IRHA
-D 40pin QFN, 8KB + 256B Flash Memory, 512B RAM
+D 8kB + 256B Flash, 512B RAM, QFN-40
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
 $ENDCMP
 #
 $CMP MSP430F2232IYFF
-D 49ball BGA, 8KB + 256B Flash Memory, 512B RAM
+D 8kB + 256B Flash, 512B RAM, BGA-49
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
 $ENDCMP
 #
 $CMP MSP430F2234IDA
-D 38pin TSSOP, 8KB + 256B Flash Memory, 512B RAM
+D 8kB + 256B Flash, 512B RAM, TSSOP-38
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
 $ENDCMP
 #
 $CMP MSP430F2234IRHA
-D 40pin QFN, 8KB + 256B Flash Memory, 512B RAM
+D 8kB + 256B Flash, 512B RAM, QFN-40
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
 $ENDCMP
 #
 $CMP MSP430F2234IYFF
-D 49ball BGA, 8KB + 256B Flash Memory, 512B RAM
+D 8kB + 256B Flash, 512B RAM, BGA-49
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
 $ENDCMP
 #
 $CMP MSP430F2252IDA
-D 38pin TSSOP, 16KB + 256B Flash Memory, 512B RAM
+D 16kB + 256B Flash, 512B RAM, TSSOP-38
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
 $ENDCMP
 #
 $CMP MSP430F2252IRHA
-D 40pin QFN, 16KB + 256B Flash Memory, 512B RAM
+D 16kB + 256B Flash, 512B RAM, QFN-40
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
 $ENDCMP
 #
 $CMP MSP430F2252IYFF
-D 49ball BGA, 16KB + 256B Flash Memory, 512B RAM
+D 16kB + 256B Flash, 512B RAM, BGA-49
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
 $ENDCMP
 #
 $CMP MSP430F2254IDA
-D 38pin TSSOP, 16KB + 256B Flash Memory, 512B RAM
+D 16kB + 256B Flash, 512B RAM, TSSOP-38
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
 $ENDCMP
 #
 $CMP MSP430F2254IRHA
-D 40pin QFN, 16KB + 256B Flash Memory, 512B RAM
+D 16kB + 256B Flash, 512B RAM, QFN-40
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
 $ENDCMP
 #
 $CMP MSP430F2254IYFF
-D 49ball BGA, 16KB + 256B Flash Memory, 512B RAM
+D 16kB + 256B Flash, 512B RAM, BGA-49
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
 $ENDCMP
 #
 $CMP MSP430F2272IDA
-D 38pin TSSOP, 32KB + 256B Flash Memory, 1KB RAM
+D 32kB + 256B Flash, 1kB RAM, TSSOP-38
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
 $ENDCMP
 #
 $CMP MSP430F2272IRHA
-D 40pin QFN, 32KB + 256B Flash Memory, 1KB RAM
+D 32kB + 256B Flash, 1kB RAM, QFN-40
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
 $ENDCMP
 #
 $CMP MSP430F2272IYFF
-D 49ball BGA, 32KB + 256B Flash Memory, 1KB RAM
+D 32kB + 256B Flash, 1kB RAM, BGA-49
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
 $ENDCMP
 #
 $CMP MSP430F2274IDA
-D 38pin TSSOP, 32KB + 256B Flash Memory, 1KB RAM
+D 32kB + 256B Flash, 1kB RAM, TSSOP-38
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
 $ENDCMP
 #
 $CMP MSP430F2274IRHA
-D 40pin QFN, 32KB + 256B Flash Memory, 1KB RAM
+D 32kB + 256B Flash, 1kB RAM, QFN-40
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
 $ENDCMP
 #
 $CMP MSP430F2274IYFF
-D 49ball BGA, 32KB + 256B Flash Memory, 1KB RAM
+D 32kB + 256B Flash, 1kB RAM, BGA-49
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
 $ENDCMP
 #
 $CMP MSP430F2330IRHA
-D 40pin QFN, 8KB + 256B Flash Memory, 1KB RAM
+D 8kB + 256B Flash, 1kB RAM, QFN-40
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f2330.pdf
 $ENDCMP
 #
 $CMP MSP430F2330IYFF
-D 49ball BGA, 8KB + 256B Flash Memory, 1KB RAM
+D 8kB + 256B Flash, 1kB RAM, BGA-49
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f2330.pdf
 $ENDCMP
 #
 $CMP MSP430F2350IRHA
-D MSP430F2340, 40pin QFN, 16KB + 256B Flash Memory, 2KB RAM
+D 16kB + 256B Flash, 2kB RAM, QFN-40
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f2330.pdf
 $ENDCMP
 #
 $CMP MSP430F2350IYFF
-D 49ball BGA, 16KB + 256B Flash Memory, 2KB RAM
+D 16kB + 256B Flash, 2kB RAM, BGA-49
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f2330.pdf
 $ENDCMP
 #
 $CMP MSP430F2370IRHA
-D 40pin QFN, 32KB + 256B Flash Memory, 2KB RAM
+D 32kB + 256B Flash, 2kB RAM, QFN-40
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f2330.pdf
 $ENDCMP
 #
 $CMP MSP430F2370IYFF
-D 49ball BGA, 32KB + 256B Flash Memory, 2KB RAM
+D 32kB + 256B Flash, 2kB RAM, BGA-49
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f2330.pdf
 $ENDCMP
 #
 $CMP MSP430F5217IRGC
-D 64pin QFN, 64KB Flash Memory, 8KB RAM
+D 64kB Flash, 8kB RAM, QFN-64
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5227.pdf
 $ENDCMP
 #
 $CMP MSP430F5217IYFF
-D 64ball BGA, 64KB Flash Memory, 8KB RAM
+D 64kB Flash, 8kB RAM, BGA-64
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5227.pdf
 $ENDCMP
 #
 $CMP MSP430F5219IRGC
-D 64pin QFN, 128KB Flash Memory, 8KB RAM
+D 128kB Flash, 8kB RAM, QFN-64
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5227.pdf
 $ENDCMP
 #
 $CMP MSP430F5219IYFF
-D 64ball BGA, 128KB Flash Memory, 8KB RAM
+D 128kB Flash, 8kB RAM, BGA-64
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5227.pdf
 $ENDCMP
 #
 $CMP MSP430F5227IRGC
-D 64pin QFN, 64KB Flash Memory, 8KB RAM
+D 64kB Flash, 8kB RAM, QFN-64
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5227.pdf
 $ENDCMP
 #
 $CMP MSP430F5227IYFF
-D 64ball BGA, 64KB Flash Memory, 8KB RAM
+D 64kB Flash, 8kB RAM, BGA-64
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5227.pdf
 $ENDCMP
 #
 $CMP MSP430F5229IRGC
-D 64pin QFN, 128KB Flash Memory, 8KB RAM
+D 128kB Flash, 8kB RAM, QFN-64
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5227.pdf
 $ENDCMP
 #
 $CMP MSP430F5229IYFF
-D 64ball BGA, 128KB Flash Memory, 8KB RAM
+D 128kB Flash, 8kB RAM, BGA-64
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5227.pdf
 $ENDCMP
 #
 $CMP MSP430F5232IRGZ
-D MSP430F2532, 48pin QFN, 64KB Flash Memory, 8KB RAM
+D 64kB Flash, 8kB RAM, QFN-48
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5242.pdf
 $ENDCMP
 #
 $CMP MSP430F5234IRGZ
-D MSP430F2534, 48pin QFN, 128KB Flash Memory, 8KB RAM
+D 128kB Flash, 8kB RAM, QFN-48
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5242.pdf
 $ENDCMP
 #
 $CMP MSP430F5237IRGC
-D 64pin QFN, 64KB Flash Memory, 8KB RAM
+D 64kB Flash, 8kB RAM, QFN-64
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5242.pdf
 $ENDCMP
 #
 $CMP MSP430F5239IRGC
-D 64pin QFN, 128KB Flash Memory, 8KB RAM
+D 128kB Flash, 8kB RAM, QFN-64
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5242.pdf
 $ENDCMP
 #
 $CMP MSP430F5242IRGZ
-D MSP430F2542, 48pin QFN, 64KB Flash Memory, 8KB RAM
+D 64kB Flash, 8kB RAM, QFN-48
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5242.pdf
 $ENDCMP
 #
 $CMP MSP430F5244IRGZ
-D MSP430F2544, 48pin QFN, 128KB Flash Memory, 8KB RAM
+D 128kB Flash, 8kB RAM, QFN-48
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5242.pdf
 $ENDCMP
 #
 $CMP MSP430F5247IRGC
-D 64pin QFN, 64KB Flash Memory, 8KB RAM
+D 64kB Flash, 8kB RAM, QFN-64
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5242.pdf
 $ENDCMP
 #
 $CMP MSP430F5249IRGC
-D 64pin QFN, 128KB Flash Memory, 8KB RAM
+D 128kB Flash, 8kB RAM, QFN-64
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5242.pdf
 $ENDCMP
 #
 $CMP MSP430F5304IPT
-D 48pin LQFN, 8KB Flash Memory, 6KB RAM
+D 8kB Flash, 6kB RAM, LQFP-48
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5304.pdf
 $ENDCMP
 #
 $CMP MSP430F5304IRGZ
-D 48pin QFN, 8KB Flash Memory, 6KB RAM
+D 8kB Flash, 6kB RAM, QFN-48
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5304.pdf
 $ENDCMP
 #
 $CMP MSP430F5308IPT
-D 48pin LQFN, 16KB Flash Memory, 6KB RAM
+D 16kB Flash, 6kB RAM, LQFP-48
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5304.pdf
 $ENDCMP
 #
 $CMP MSP430F5308IRGC
-D 64pin QFN, 16KB Flash Memory, 6KB RAM
+D 16kB Flash, 6kB RAM, QFN-64
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5304.pdf
 $ENDCMP
 #
 $CMP MSP430F5308IRGZ
-D 48pin LQFN, 16KB Flash Memory, 6KB RAM
+D 16kB Flash, 6kB RAM, QFN-48
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5304.pdf
 $ENDCMP
 #
 $CMP MSP430F5308IZQE
-D 80ball BGA, 16KB Flash Memory, 6KB RAM
+D 16kB Flash, 6kB RAM, BGA-80
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5304.pdf
 $ENDCMP
 #
 $CMP MSP430F5309IPT
-D 48pin LQFN, 24KB Flash Memory, 6KB RAM
+D 24kB Flash, 6kB RAM, LQFP-48
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5304.pdf
 $ENDCMP
 #
 $CMP MSP430F5309IRGC
-D 64pin QFN, 24KB Flash Memory, 6KB RAM
+D 24kB Flash, 6kB RAM, QFN-64
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5304.pdf
 $ENDCMP
 #
 $CMP MSP430F5309IRGZ
-D 48pin QFN, 24KB Flash Memory, 6KB RAM
+D 24kB Flash, 6kB RAM, QFN-48
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5304.pdf
 $ENDCMP
 #
 $CMP MSP430F5309IZQE
-D 80ball BGA, 24KB Flash Memory, 6KB RAM
+D 24kB Flash, 6kB RAM, BGA-80
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5304.pdf
 $ENDCMP
 #
 $CMP MSP430F5310IPT
-D 48pin LQFN, 32KB Flash Memory, 6KB RAM
+D 32kB Flash, 6kB RAM, LQFP-48
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5304.pdf
 $ENDCMP
 #
 $CMP MSP430F5310IRGC
-D 64pin QFN, 32KB Flash Memory, 6KB RAM
+D 32kB Flash, 6kB RAM, QFN-64
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5304.pdf
 $ENDCMP
 #
 $CMP MSP430F5310IRGZ
-D 48pin QFN, 32KB Flash Memory, 6KB RAM
+D 32kB Flash, 6kB RAM, QFN-48
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5304.pdf
 $ENDCMP
 #
 $CMP MSP430F5310IZQE
-D 80ball BGA, 32KB Flash Memory, 6KB RAM
+D 32kB Flash, 6kB RAM, BGA-80
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5304.pdf
 $ENDCMP
 #
 $CMP MSP430F5333IPZ
-D 100pin VQFP, 128KB Flash Memory, 18KB RAM
+D 128kB Flash, 10kB RAM, LQFP-100
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5333.pdf
 $ENDCMP
 #
 $CMP MSP430F5333IZQW
-D 113ball BGA, 128KB Flash Memory, 18KB RAM
+D 128kB Flash, 10kB RAM, BGA-113
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5333.pdf
 $ENDCMP
 #
 $CMP MSP430F5335IPZ
-D 100pin VQFP, 256KB Flash Memory, 18KB RAM
+D 256kB Flash, 18kB RAM, LQFP-100
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5333.pdf
 $ENDCMP
 #
 $CMP MSP430F5335IZQW
-D 113ball BGA, 256KB Flash Memory, 18KB RAM
+D 256kB Flash, 18kB RAM, BGA-113
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5333.pdf
 $ENDCMP
 #
 $CMP MSP430F5336IPZ
-D 100pin VQFP, 128KB Flash Memory, 18KB RAM
+D 128kB Flash, 18kB RAM, LQFP-100
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5333.pdf
 $ENDCMP
 #
 $CMP MSP430F5336IZQW
-D 113ball BGA, 128KB Flash Memory, 18KB RAM
+D 128kB Flash, 18kB RAM, BGA-113
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5333.pdf
 $ENDCMP
 #
 $CMP MSP430F5338IPZ
-D 100pin VQFP, 256KB Flash Memory, 18KB RAM
+D 256kB Flash, 18kB RAM, LQFP-100
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5333.pdf
 $ENDCMP
 #
 $CMP MSP430F5338IZQW
-D 113ball BGA, 128KB Flash Memory, 18KB RAM
+D 128kB Flash, 18kB RAM, BGA-113
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5333.pdf
 $ENDCMP
 #
 $CMP MSP430F5340IRGZ
-D 48pin QFN, 64KB Flash Memory, 6KB RAM
+D 64kB Flash, 6kB RAM, QFN-48
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5340.pdf
 $ENDCMP
 #
 $CMP MSP430F5341IRGZ
-D 48pin QFN, 96KB Flash Memory, 8KB RAM
+D 96kB Flash, 8kB RAM, QFN-48
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5340.pdf
 $ENDCMP
 #
 $CMP MSP430F5342IRGZ
-D MSP430F5340, 48pin QFN, 128KB Flash Memory, 10KB RAM
+D 128kB Flash, 10kB RAM, QFN-48
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5340.pdf
 $ENDCMP
 #
 $CMP MSP430F5358IZQW
-D 113ball BGA, 384KB Flash Memory, 34KB RAM
+D 384kB Flash, 34kB RAM, BGA-113
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5358.pdf
 $ENDCMP
 #
 $CMP MSP430F5359IZQW
-D 113ball BGA, 512KB Flash Memory, 66KB RAM
+D 512kB Flash, 66kB RAM, BGA-113
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5358.pdf
 $ENDCMP
 #
 $CMP MSP430F5500IRGZ
-D 48pin QFN, 8KB Flash Memory, 4 + 2KB SRAM
+D 8kB Flash, 4kB + 2kB RAM, QFN-48
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5510.pdf
 $ENDCMP
 #
 $CMP MSP430F5501IRGZ
-D 48pin QFN, 16KB Flash Memory, 4 + 2KB SRAM
+D 16kB Flash, 4kB + 2kB RAM, QFN-48
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5510.pdf
 $ENDCMP
 #
 $CMP MSP430F5502IRGZ
-D 48pin QFN, 24KB Flash Memory, 4 + 2KB SRAM
+D 24kB Flash, 4kB + 2kB RAM, QFN-48
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5510.pdf
 $ENDCMP
 #
 $CMP MSP430F5503IRGZ
-D 48pin QFN, 32KB Flash Memory, 4 + 2KB SRAM
+D 32kB Flash, 4kB + 2kB RAM, QFN-48
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5510.pdf
 $ENDCMP
 #
 $CMP MSP430F5504IRGZ
-D 48pin QFN, 8KB Flash Memory, 4 + 2KB SRAM
+D 8kB Flash, 4kB + 2kB RAM, QFN-48
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5510.pdf
 $ENDCMP
 #
 $CMP MSP430F5505IRGZ
-D 48pin QFN, 16KB Flash Memory, 4 + 2KB SRAM
+D 16kB Flash, 4kB + 2kB RAM, QFN-48
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5510.pdf
 $ENDCMP
 #
 $CMP MSP430F5506IRGZ
-D 48pin QFN, 24KB Flash Memory, 4 + 2KB SRAM
+D 24kB Flash, 4kB + 2kB RAM, QFN-48
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5510.pdf
 $ENDCMP
 #
 $CMP MSP430F5507IRGZ
-D 48pin QFN, 32KB Flash Memory, 4 + 2KB SRAM
+D 32kB Flash, 4kB + 2kB RAM, QFN-48
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5510.pdf
 $ENDCMP
 #
 $CMP MSP430F5508IRGZ
-D 48pin QFN, 16KB Flash Memory, 4 + 2KB SRAM
+D 16kB Flash, 4kB + 2kB RAM, QFN-48
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5510.pdf
 $ENDCMP
 #
 $CMP MSP430F5509IRGZ
-D 48pin QFN, 24KB Flash Memory, 4 + 2KB SRAM
+D 24kB Flash, 4kB + 2kB RAM, QFN-48
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5510.pdf
 $ENDCMP
 #
 $CMP MSP430F5510IRGZ
-D 48pin QFN, 32KB Flash Memory, 4 + 2KB SRAM
+D 32kB Flash, 4kB + 2kB RAM, QFN-48
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5510.pdf
 $ENDCMP
 #
 $CMP MSP430F5524IYFF
-D 64ball BGA, 64KB Flash Memory, 4 + 2KB SRAM
+D 64kB Flash, 4kB + 2kB RAM, BGA-64
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5524.pdf
 $ENDCMP
 #
 $CMP MSP430F5526IYFF
-D 64ball BGA, 96KB Flash Memory, 6 + 2KB SRAM
+D 96kB Flash, 6kB + 2kB RAM, BGA-64
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5524.pdf
 $ENDCMP
 #
 $CMP MSP430F5528IYFF
-D 64ball BGA, 128KB Flash Memory, 8 + 2KB SRAM
+D 128kB Flash, 8kB + 2kB RAM, BGA-64
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5524.pdf
 $ENDCMP
 #
 $CMP MSP430F5630IZQW
-D 113ball BGA, 128KB Flash Memory, 16 + 2KB RAM
+D 128kB Flash, 16kB + 2kB RAM, BGA-113
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5630.pdf
 $ENDCMP
 #
 $CMP MSP430F5631IZQW
-D 113ball BGA, 192KB Flash Memory, 16 + 2KB RAM
+D 192kB Flash, 16kB + 2kB RAM, BGA-113
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5630.pdf
 $ENDCMP
 #
 $CMP MSP430F5632IZQW
-D 113ball BGA, 256KB Flash Memory, 16 + 2KB RAM
+D 256kB Flash, 16kB + 2kB RAM, BGA-113
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5630.pdf
 $ENDCMP
 #
 $CMP MSP430F5633IZQW
-D 113ball BGA, 128KB Flash Memory, 16 + 2KB RAM
+D 128kB Flash, 16kB + 2kB RAM, BGA-113
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5630.pdf
 $ENDCMP
 #
 $CMP MSP430F5634IZQW
-D 113ball BGA, 192KB Flash Memory, 16 + 2KB RAM
+D 192kB Flash, 16kB + 2kB RAM, BGA-113
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5630.pdf
 $ENDCMP
 #
 $CMP MSP430F5635IZQW
-D 113ball BGA, 256KB Flash Memory, 16 + 2KB RAM
+D 256kB Flash, 16kB + 2kB RAM, BGA-113
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5630.pdf
 $ENDCMP
 #
 $CMP MSP430F5636IZQW
-D 113ball BGA, 128KB Flash Memory, 16 + 2KB RAM
+D 128kB Flash, 16kB + 2kB RAM, BGA-113
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5630.pdf
 $ENDCMP
 #
 $CMP MSP430F5637IZQW
-D 113ball BGA, 192KB Flash Memory, 16 + 2KB RAM
+D 192kB Flash, 16kB + 2kB RAM, BGA-113
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5630.pdf
 $ENDCMP
 #
 $CMP MSP430F5638IZQW
-D 113ball BGA, 256KB Flash Memory, 16 + 2KB RAM
+D 256kB Flash, 16kB + 2kB RAM, BGA-113
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5630.pdf
 $ENDCMP
 #
 $CMP MSP430F5658IZQW
-D 113ball BGA, 384KB Flash Memory, 34KB RAM
+D 384kB Flash, 32kB + 2kB RAM, BGA-113
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5658.pdf
 $ENDCMP
 #
 $CMP MSP430F5659IZQW
-D 113ball BGA, 512KB Flash Memory, 66KB RAM
+D 512kB Flash, 64kB + 2kB RAM, BGA-113
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5658.pdf
 $ENDCMP
 #
 $CMP MSP430FR5720IRGE
-D 24pin QFN, 4KB FRAM Memory, 1KB SRAM
+D 4kB FRAM, 1kB SRAM, QFN-24
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430fr5720.pdf
 $ENDCMP
 #
 $CMP MSP430FR5722IRGE
-D 24pin QFN, 8KB FRAM Memory, 1KB SRAM
+D 8kB FRAM, 1kB SRAM, QFN-24
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430fr5720.pdf
 $ENDCMP
 #
 $CMP MSP430FR5724IRGE
-D 24pin QFN, 8KB FRAM Memory, 1KB SRAM
+D 8kB FRAM, 1kB SRAM, QFN-24
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430fr5720.pdf
 $ENDCMP
 #
 $CMP MSP430FR5726IRGE
-D 24pin QFN, 16KB FRAM Memory, 1KB SRAM
+D 16kB FRAM, 1kB SRAM, QFN-24
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430fr5720.pdf
 $ENDCMP
 #
 $CMP MSP430FR5728IRGE
-D 24pin QFN, 16KB FRAM Memory, 1KB SRAM
+D 16kB FRAM, 1kB SRAM, QFN-24
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430fr5720.pdf
 $ENDCMP
 #
 $CMP MSP430FR5730IRGE
-D 24pin QFN, 4KB FRAM Memory, 1KB SRAM
+D 4kB FRAM, 1kB SRAM, QFN-24
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430fr5720.pdf
 $ENDCMP
 #
 $CMP MSP430FR5732IRGE
-D 24pin QFN, 8KB FRAM Memory, 1KB SRAM
+D 8kB FRAM, 1kB SRAM, QFN-24
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430fr5720.pdf
 $ENDCMP
 #
 $CMP MSP430FR5734IRGE
-D 24pin QFN, 8KB FRAM Memory, 1KB SRAM
+D 8kB FRAM, 1kB SRAM, QFN-24
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430fr5720.pdf
 $ENDCMP
 #
 $CMP MSP430FR5736IRGE
-D 24pin QFN, 16KB FRAM Memory, 1KB SRAM
+D 16kB FRAM, 1kB SRAM, QFN-24
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430fr5720.pdf
 $ENDCMP
 #
 $CMP MSP430FR5738IRGE
-D 24pin QFN, 16KB FRAM Memory, 1KB SRAM
+D 16kB FRAM, 1kB SRAM, QFN-24
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430fr5720.pdf
 $ENDCMP
 #
 $CMP MSP430G2001IN14
-D 14pin PDIP, 512B Flash Memory, 128B RAM
+D 512B Flash, 128B RAM, DIP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
 $ENDCMP
 #
 $CMP MSP430G2001IPW14
-D MSP430G2001, 14pin TSSOP, 512B Flash Memory, 128B RAM
+D 512B Flash, 128B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
 $ENDCMP
 #
 $CMP MSP430G2001IRSA16
-D MSP430G2001, 16pin QFN, 512B Flash Memory, 128B RAM
+D 512B Flash, 128B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
 $ENDCMP
 #
 $CMP MSP430G2101IN14
-D 14pin PDIP, 1KB Flash Memory, 128B RAM
+D 1kB Flash, 128B RAM, DIP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
 $ENDCMP
 #
 $CMP MSP430G2101IPW14
-D MSP430G2101, 14pin TSSOP, 1KB Flash Memory, 128B RAM
+D 1kB Flash, 128B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
 $ENDCMP
 #
 $CMP MSP430G2101IRSA16
-D MSP430G2101, 16pin QFN, 1KB Flash Memory, 128B RAM
+D 1kB Flash, 128B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
 $ENDCMP
 #
 $CMP MSP430G2102IN20
-D 20pin PDIP, 1KB Flash Memory, 128B RAM
+D 1kB Flash, 128B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2102IPW14
-D MSP430G2102, 14pin TSSOP, 1KB Flash Memory, 128B RAM
+D 1kB Flash, 128B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2102IPW20
-D MSP430G2102, 20pin TSSOP, 1KB Flash Memory, 128B RAM
+D 1kB Flash, 128B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2102IRSA16
-D MSP430G2102, 16pin QFN, 1KB Flash Memory, 128B RAM
+D 1kB Flash, 128B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2111IN14
-D 14pin PDIP, 1KB Flash Memory, 128B RAM
+D 1kB Flash, 128B RAM, DIP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
 $ENDCMP
 #
 $CMP MSP430G2111IPW14
-D MSP430G2111, 14pin TSSOP, 1KB Flash Memory, 128B RAM
+D 1kB Flash, 128B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
 $ENDCMP
 #
 $CMP MSP430G2111IRSA16
-D MSP430G2111, 16pin QFN, 1KB Flash Memory, 128B RAM
+D 1kB Flash, 128B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
 $ENDCMP
 #
 $CMP MSP430G2112IN20
-D 20pin PDIP, 1KB Flash Memory, 128B RAM
+D 1kB Flash, 128B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2112IPW14
-D MSP430G2112, 14pin TSSOP, 1KB Flash Memory, 128B RAM
+D 1kB Flash, 128B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2112IPW20
-D MSP430G2112, 20pin TSSOP, 1KB Flash Memory, 128B RAM
+D 1kB Flash, 128B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2112IRSA16
-D MSP430G2112, 16pin QFN, 1KB Flash Memory, 128B RAM
+D 1kB Flash, 128B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2113IPW20
-D MSP430G2113, 20pin TSSOP, 1KB Flash Memory, 256B RAM
+D 1kB Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
 $ENDCMP
 #
 $CMP MSP430G2121IN14
-D 14pin PDIP, 1KB Flash Memory, 128B RAM
+D 1kB Flash, 128B RAM, DIP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2121.pdf
 $ENDCMP
 #
 $CMP MSP430G2121IPW14
-D MSP430G2121, 14pin TSSOP, 1KB Flash Memory, 128B RAM
+D 1kB Flash, 128B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2121.pdf
 $ENDCMP
 #
 $CMP MSP430G2121IRSA16
-D MSP430G2121, 16pin QFN, 1KB Flash Memory, 128B RAM
+D 1kB Flash, 128B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2121.pdf
 $ENDCMP
 #
 $CMP MSP430G2131IN14
-D MSP430G2121, 14pin PDIP, 1KB Flash Memory, 128B RAM
+D 1kB Flash, 128B RAM, DIP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2121.pdf
 $ENDCMP
 #
 $CMP MSP430G2131IPW14
-D MSP430G2121, 14pin PDIP, 1KB Flash Memory, 128B RAM
+D 1kB Flash, 128B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2121.pdf
 $ENDCMP
 #
 $CMP MSP430G2131IRSA16
-D MSP430G2131, 16pin QFN, 1KB Flash Memory, 128B RAM
+D 1kB Flash, 128B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2121.pdf
 $ENDCMP
 #
 $CMP MSP430G2132IN20
-D 20pin PDIP, 1KB Flash Memory, 128B RAM
+D 1kB Flash, 128B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2132IPW14
-D MSP430G2132, 14pin TSSOP, 1KB Flash Memory, 128B RAM
+D 1kB Flash, 128B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2132IPW20
-D MSP430G2132, 20pin TSSOP, 1KB Flash Memory, 128B RAM
+D 1kB Flash, 128B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2132IRSA16
-D MSP430G2132, 16pin QFN, 1KB Flash Memory, 128B RAM
+D 1kB Flash, 128B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2152IN20
-D 20pin PDIP, 1KB Flash Memory, 128B RAM
+D 1kB Flash, 128B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2152IPW14
-D MSP430G2152, 14pin TSSOP, 1KB Flash Memory, 128B RAM
+D 1kB Flash, 128B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2152IPW20
-D MSP430G2152, 20pin TSSOP, 1KB Flash Memory, 128B RAM
+D 1kB Flash, 128B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2152IRSA16
-D MSP430G2152, 16pin QFN, 1KB Flash Memory, 128B RAM
+D 1kB Flash, 128B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2152.pdf
 $ENDCMP
 #
 $CMP MSP430G2153IN20
-D MSP430G2113, 20pin PDIP, 1KB Flash Memory, 256B RAM
+D 1kB Flash, 256B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
 $ENDCMP
 #
 $CMP MSP430G2153IPW20
-D MSP430G2113, 20pin TSSOP, 1KB Flash Memory, 256B RAM
+D 1kB Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
 $ENDCMP
 #
 $CMP MSP430G2153IPW28
-D MSP430G2153, 28pin TQFP, 1KB Flash Memory, 256B RAM
+D 1kB Flash, 256B RAM, TSSOP-28
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2153.pdf
 $ENDCMP
 #
 $CMP MSP430G2153IRHB32
-D MSP430G2153, 32pin QFN, 1KB Flash Memory, 256B RAM
+D 1kB Flash, 256B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2153.pdf
 $ENDCMP
 #
 $CMP MSP430G2201IN14
-D 14pin PDIP, 2KB Flash Memory, 128B RAM
+D 2kB Flash, 128B RAM, DIP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
 $ENDCMP
 #
 $CMP MSP430G2201IPW14
-D MSP430G2201, 14pin TSSOP, 2KB Flash Memory, 128B RAM
+D 2kB Flash, 128B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
 $ENDCMP
 #
 $CMP MSP430G2201IRSA16
-D MSP430G2201, 16pin QFN, 2KB Flash Memory, 128B RAM
+D 2kB Flash, 128B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
 $ENDCMP
 #
 $CMP MSP430G2202IN20
-D 20pin PDIP, 2KB Flash Memory, 256B RAM
+D 2kB Flash, 256B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2202IPW14
-D MSP430G2202, 14pin TSSOP, 2KB Flash Memory, 256B RAM
+D 2kB Flash, 256B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2202IPW20
-D MSP430G2202, 20pin TSSOP, 2KB Flash Memory, 256B RAM
+D 2kB Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2202IRSA16
-D MSP430G2202, 16pin QFN, 2KB Flash Memory, 256B RAM
+D 2kB Flash, 256B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2203IN20
-D 20pin PDIP, 2KB Flash Memory, 256B RAM
+D 2kB Flash, 256B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2203.pdf
 $ENDCMP
 #
 $CMP MSP430G2203IPW20
-D MSP430G2203, 20pin TSSOP, 2KB Flash Memory, 256B RAM
+D 2kB Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2203.pdf
 $ENDCMP
 #
 $CMP MSP430G2203IPW28
-D MSP430G2203, 28pin TSSOP, 2KB Flash Memory, 256B RAM
+D 2kB Flash, 256B RAM, TSSOP-28
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2203.pdf
 $ENDCMP
 #
 $CMP MSP430G2203IRHB32
-D MSP430G2203, 32pin QFN, 2KB Flash Memory, 256B RAM
+D 2kB Flash, 256B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2203.pdf
 $ENDCMP
 #
 $CMP MSP430G2210ID
-D 8pin PDIP, 2KB + 256B Flash Memory, 128B RAM
+D 2kB + 256B Flash, 128B RAM, SOIC-8
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2210.pdf
 $ENDCMP
 #
 $CMP MSP430G2211IN14
-D 14pin PDIP, 2KB Flash Memory, 128B RAM
+D 2kB Flash, 128B RAM, DIP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
 $ENDCMP
 #
 $CMP MSP430G2211IPW14
-D MSP430G2211, 14pin TSSOP, 1KB Flash Memory, 128B RAM
+D 2kB Flash, 128B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
 $ENDCMP
 #
 $CMP MSP430G2211IRSA16
-D MSP430G2211, 16pin QFN, 2KB Flash Memory, 128B RAM
+D 2kB Flash, 128B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
 $ENDCMP
 #
 $CMP MSP430G2212IN20
-D 20pin PDIP, 2KB Flash Memory, 256B RAM
+D 2kB Flash, 256B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2212IPW14
-D MSP430G2212, 14pin TSSOP, 2KB Flash Memory, 256B RAM
+D 2kB Flash, 256B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2212IPW20
-D MSP430G2212, 20pin TSSOP, 2KB Flash Memory, 256B RAM
+D 2kB Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2212IRSA16
-D MSP430G2212, 16pin QFN, 2KB Flash Memory, 256B RAM
+D 2kB Flash, 256B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2213IN20
-D 20pin PDIP, 2KB Flash Memory, 256B RAM
+D 2kB Flash, 256B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
 $ENDCMP
 #
 $CMP MSP430G2213IPW20
-D MSP430G2213, 20pin TSSOP, 2KB Flash Memory, 256B RAM
+D 2kB Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
 $ENDCMP
 #
 $CMP MSP430G2213IPW28
-D MSP430G2213, 28pin TSSOP, 2KB Flash Memory, 256B RAM
+D 2kB Flash, 256B RAM, TSSOP-28
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2213.pdf
 $ENDCMP
 #
 $CMP MSP430G2213IRHB32
-D MSP430G2213, 32pin QFN, 2KB Flash Memory, 256B RAM
+D 2kB Flash, 256B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2213.pdf
 $ENDCMP
 #
 $CMP MSP430G2221IN14
-D 14pin PDIP, 2KB Flash Memory, 128B RAM
+D 2kB Flash, 128B RAM, DIP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2121.pdf
 $ENDCMP
 #
 $CMP MSP430G2221IPW14
-D MSP430G2221, 14pin TSSOP, 2KB Flash Memory, 128B RAM
+D 2kB Flash, 128B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2121.pdf
 $ENDCMP
 #
 $CMP MSP430G2221IRSA16
-D MSP430G2221, 16pin QFN, 2KB Flash Memory, 128B RAM
+D 2kB Flash, 128B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2121.pdf
 $ENDCMP
 #
 $CMP MSP430G2230ID
-D 8pin SOIC, 2KB + 256B Flash Memory, 128B RAM
+D 2kB + 256B Flash, 128B RAM, SOIC-8
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2230.pdf
 $ENDCMP
 #
 $CMP MSP430G2231IN14
-D 14pin PDIP, 2KB Flash Memory, 128B RAM
+D 2kB Flash, 128B RAM, DIP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2121.pdf
 $ENDCMP
 #
 $CMP MSP430G2231IPW14
-D MSP430G2231, 14pin PDIP, 2KB Flash Memory, 128B RAM
+D 2kB Flash, 128B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2121.pdf
 $ENDCMP
 #
 $CMP MSP430G2231IRSA16
-D MSP430G2231, 16pin QFN, 2KB Flash Memory, 128B RAM
+D 2kB Flash, 128B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2121.pdf
 $ENDCMP
 #
 $CMP MSP430G2232IN20
-D 20pin PDIP, 2KB Flash Memory, 256B RAM
+D 2kB Flash, 256B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2232IPW14
-D MSP430G2232, 14pin TSSOP, 2KB Flash Memory, 256B RAM
+D 2kB Flash, 256B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2232IPW20
-D MSP430G2232, 20pin TSSOP, 2KB Flash Memory, 256B RAM
+D 2kB Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2232IRSA16
-D MSP430G2232, 16pin QFN, 2KB Flash Memory, 256B RAM
+D 2kB Flash, 256B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2233IN20
-D 20pin PDIP, 2KB Flash Memory, 256B RAM
+D 2kB Flash, 256B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
 $ENDCMP
 #
 $CMP MSP430G2233IPW20
-D MSP430G2233, 20pin TSSOP, 2KB Flash Memory, 256B RAM
+D 2kB Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
 $ENDCMP
 #
 $CMP MSP430G2233IPW28
-D MSP430G2233, 28pin TSSOP, 2KB Flash Memory, 256B RAM
+D 2kB Flash, 256B RAM, TSSOP-28
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
 $ENDCMP
 #
 $CMP MSP430G2233IRHB32
-D MSP430G2233, 32pin QFN, 2KB Flash Memory, 256B RAM
+D 2kB Flash, 256B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
 $ENDCMP
 #
 $CMP MSP430G2252IN20
-D 20pin PDIP, 2KB Flash Memory, 256B RAM
+D 2kB Flash, 256B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2252IPW14
-D MSP430G2252, 14pin TSSOP, 2KB Flash Memory, 256B RAM
+D 2kB Flash, 256B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2252IPW20
-D MSP430G2252, 20pin TSSOP, 2KB Flash Memory, 256B RAM
+D 2kB Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2252IRSA16
-D MSP430G2252, 16pin QFN, 2KB Flash Memory, 256B RAM
+D 2kB Flash, 256B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2152.pdf
 $ENDCMP
 #
 $CMP MSP430G2253IN20
-D 20pin PDIP, 2KB Flash Memory, 256B RAM
+D 2kB Flash, 256B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
 $ENDCMP
 #
 $CMP MSP430G2253IPW20
-D MSP430G2253, 20pin TSSOP, 2KB Flash Memory, 256B RAM
+D 2kB Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
 $ENDCMP
 #
 $CMP MSP430G2253IPW28
-D MSP430G2253, 28pin TQFP, 2KB Flash Memory, 256B RAM
+D 2kB Flash, 256B RAM, TSSOP-28
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2153.pdf
 $ENDCMP
 #
 $CMP MSP430G2253IRHB32
-D MSP430G2253, 32pin QFN, 2KB Flash Memory, 256B RAM
+D 2kB Flash, 256B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2153.pdf
 $ENDCMP
 #
 $CMP MSP430G2302IN20
-D 20pin PDIP, 4KB Flash Memory, 256B RAM
+D 4kB Flash, 256B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2302IPW14
-D MSP430G2302, 14pin TSSOP, 4KB Flash Memory, 256B RAM
+D 4kB Flash, 256B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2302IPW20
-D MSP430G2302, 20pin TSSOP, 4KB Flash Memory, 256B RAM
+D 4kB Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2302IRSA16
-D MSP430G2302, 16pin QFN, 4KB Flash Memory, 256B RAM
+D 4kB Flash, 256B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2303IN20
-D 20pin PDIP, 4KB Flash Memory, 256B RAM
+D 4kB Flash, 256B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2203.pdf
 $ENDCMP
 #
 $CMP MSP430G2303IPW20
-D MSP430G2303, 20pin TSSOP, 4KB Flash Memory, 256B RAM
+D 4kB Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2203.pdf
 $ENDCMP
 #
 $CMP MSP430G2303IPW28
-D MSP430G2303, 28pin TSSOP, 4KB Flash Memory, 256B RAM
+D 4kB Flash, 256B RAM, TSSOP-28
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2203.pdf
 $ENDCMP
 #
 $CMP MSP430G2303IRHB32
-D MSP430G2303, 32pin QFN, 4KB Flash Memory, 256B RAM
+D 4kB Flash, 256B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2203.pdf
 $ENDCMP
 #
 $CMP MSP430G2312IN20
-D 20pin PDIP, 4KB Flash Memory, 256B RAM
+D 4kB Flash, 256B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2312IPW14
-D MSP430G2312, 14pin TSSOP, 4KB Flash Memory, 256B RAM
+D 4kB Flash, 256B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2312IPW20
-D MSP430G2312, 20pin TSSOP, 4KB Flash Memory, 256B RAM
+D 4kB Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2312IRSA16
-D MSP430G2312, 16pin QFN, 4KB Flash Memory, 256B RAM
+D 4kB Flash, 256B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2313IN20
-D 20pin PDIP, 4KB Flash Memory, 256B RAM
+D 4kB Flash, 256B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
 $ENDCMP
 #
 $CMP MSP430G2313IPW20
-D MSP430G2313, 20pin TSSOP, 4KB Flash Memory, 256B RAM
+D 4kB Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
 $ENDCMP
 #
 $CMP MSP430G2313IPW28
-D MSP430G2313, 28pin TSSOP, 4KB Flash Memory, 256B RAM
+D 4kB Flash, 256B RAM, TSSOP-28
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2213.pdf
 $ENDCMP
 #
 $CMP MSP430G2313IRHB32
-D MSP430G2313, 32pin QFN, 4KB Flash Memory, 256B RAM
+D 4kB Flash, 256B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2213.pdf
 $ENDCMP
 #
 $CMP MSP430G2332IN20
-D 20pin PDIP, 4KB Flash Memory, 256B RAM
+D 4kB Flash, 256B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2332IPW14
-D MSP430G2332, 14pin TSSOP, 4KB Flash Memory, 256B RAM
+D 4kB Flash, 256B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2332IPW20
-D MSP430G2332, 20pin TSSOP, 4KB Flash Memory, 256B RAM
+D 4kB Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2332IRSA16
-D MSP430G2332, 16pin QFN, 4KB Flash Memory, 256B RAM
+D 4kB Flash, 256B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2333IN20
-D 20pin PDIP, 4KB Flash Memory, 256B RAM
+D 4kB Flash, 256B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
 $ENDCMP
 #
 $CMP MSP430G2333IPW20
-D MSP430G2333, 20pin TSSOP, 4KB Flash Memory, 256B RAM
+D 4kB Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
 $ENDCMP
 #
 $CMP MSP430G2333IPW28
-D MSP430G2333, 28pin TSSOP, 4KB Flash Memory, 256B RAM
+D 4kB Flash, 256B RAM, TSSOP-28
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
 $ENDCMP
 #
 $CMP MSP430G2333IRHB32
-D MSP430G2333, 32pin QFN, 4KB Flash Memory, 256B RAM
+D 4kB Flash, 256B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
 $ENDCMP
 #
 $CMP MSP430G2352IN20
-D 20pin PDIP, 4KB Flash Memory, 256B RAM
+D 4kB Flash, 256B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2352IPW14
-D MSP430G2352, 14pin TSSOP, 4KB Flash Memory, 256B RAM
+D 4kB Flash, 256B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2352IPW20
-D MSP430G2352, 20pin TSSOP, 4KB Flash Memory, 256B RAM
+D 4kB Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2352IRSA16
-D MSP430G2352, 16pin QFN, 4KB Flash Memory, 256B RAM
+D 4kB Flash, 256B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2152.pdf
 $ENDCMP
 #
 $CMP MSP430G2353IN20
-D 20pin PDIP, 4KB Flash Memory, 256B RAM
+D 4kB Flash, 256B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
 $ENDCMP
 #
 $CMP MSP430G2353IPW20
-D MSP430G2353, 20pin TSSOP, 4KB Flash Memory, 256B RAM
+D 4kB Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
 $ENDCMP
 #
 $CMP MSP430G2353IPW28
-D MSP430G2353, 28pin TQFP, 4KB Flash Memory, 256B RAM
+D 4kB Flash, 256B RAM, TSSOP-28
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2153.pdf
 $ENDCMP
 #
 $CMP MSP430G2353IRHB32
-D MSP430G2353, 32pin QFN, 4KB Flash Memory, 256B RAM
+D 4kB Flash, 256B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2153.pdf
 $ENDCMP
 #
 $CMP MSP430G2402IN20
-D 20pin PDIP, 8KB Flash Memory, 256B RAM
+D 8kB Flash, 256B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2402IPW14
-D MSP430G2402, 14pin TSSOP, 8KB Flash Memory, 256B RAM
+D 8kB Flash, 256B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2402IPW20
-D MSP430G2402, 20pin TSSOP, 8KB Flash Memory, 256B RAM
+D 8kB Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2402IRSA16
-D MSP430G2402, 16pin QFN, 8KB Flash Memory, 256B RAM
+D 8kB Flash, 256B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2403IN20
-D 20pin PDIP, 8KB Flash Memory, 512B RAM
+D 8kB Flash, 512B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2203.pdf
 $ENDCMP
 #
 $CMP MSP430G2403IPW20
-D MSP430G2403, 20pin TSSOP, 8KB Flash Memory, 512B RAM
+D 8kB Flash, 512B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2203.pdf
 $ENDCMP
 #
 $CMP MSP430G2403IPW28
-D MSP430G2403, 28pin TSSOP, 8KB Flash Memory, 512B RAM
+D 8kB Flash, 512B RAM, TSSOP-28
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2203.pdf
 $ENDCMP
 #
 $CMP MSP430G2403IRHB32
-D MSP430G2403, 32pin QFN, 8KB Flash Memory, 512B RAM
+D 8kB Flash, 512B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2203.pdf
 $ENDCMP
 #
 $CMP MSP430G2412IN20
-D 20pin PDIP, 8KB Flash Memory, 256B RAM
+D 8kB Flash, 256B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2412IPW14
-D MSP430G2412, 14pin TSSOP, 8KB Flash Memory, 256B RAM
+D 8kB Flash, 256B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2412IPW20
-D MSP430G2412, 20pin TSSOP, 8KB Flash Memory, 256B RAM
+D 8kB Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2412IRSA16
-D MSP430G2412, 16pin QFN, 8KB Flash Memory, 256B RAM
+D 8kB Flash, 256B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2413IN20
-D 20pin PDIP, 8KB Flash Memory, 512B RAM
+D 8kB Flash, 512B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
 $ENDCMP
 #
 $CMP MSP430G2413IPW20
-D MSP430G2413, 20pin TSSOP, 8KB Flash Memory, 512B RAM
+D 8kB Flash, 512B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
 $ENDCMP
 #
 $CMP MSP430G2413IPW28
-D MSP430G2413, 28pin TSSOP, 8KB Flash Memory, 512B RAM
+D 8kB Flash, 512B RAM, TSSOP-28
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2213.pdf
 $ENDCMP
 #
 $CMP MSP430G2413IRHB32
-D MSP430G2413, 32pin QFN, 8KB Flash Memory, 512B RAM
+D 8kB Flash, 512B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2213.pdf
 $ENDCMP
 #
 $CMP MSP430G2432IN20
-D 20pin PDIP, 8KB Flash Memory, 256B RAM
+D 8kB Flash, 256B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2432IPW14
-D MSP430G2432, 14pin TSSOP, 8KB Flash Memory, 256B RAM
+D 8kB Flash, 256B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2432IPW20
-D MSP430G2432, 20pin TSSOP, 8KB Flash Memory, 256B RAM
+D 8kB Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2432IRSA16
-D MSP430G2432, 16pin QFN, 8KB Flash Memory, 256B RAM
+D 8kB Flash, 256B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2433IN20
-D 20pin PDIP, 8KB Flash Memory, 512B RAM
+D 8kB Flash, 512B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
 $ENDCMP
 #
 $CMP MSP430G2433IPW20
-D MSP430G2433, 20pin TSSOP, 8KB Flash Memory, 512B RAM
+D 8kB Flash, 512B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
 $ENDCMP
 #
 $CMP MSP430G2433IPW28
-D MSP430G2433, 28pin TSSOP, 8KB Flash Memory, 512B RAM
+D 8kB Flash, 512B RAM, TSSOP-28
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
 $ENDCMP
 #
 $CMP MSP430G2433IRHB32
-D MSP430G2433, 32pin QFN, 8KB Flash Memory, 512B RAM
+D 8kB Flash, 512B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
 $ENDCMP
 #
 $CMP MSP430G2444IDA38
-D MSP430G2444, 38pin TSSOP, 8KB + 256B Flash Memory, 512B RAM
+D 8kB + 256B Flash, 512B RAM, TSSOP-38
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2444.pdf
 $ENDCMP
 #
 $CMP MSP430G2444IRHA40
-D MSP430G2444, 40pin QFN, 8KB + 256B Flash Memory, 512B RAM
+D 8kB + 256B Flash, 512B RAM, QFN-40
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2444.pdf
 $ENDCMP
 #
 $CMP MSP430G2444IYFF
-D 49ball BGA, 8KB + 256B Flash Memory, 512B RAM
+D 8kB + 256B Flash, 512B RAM, BGA-49
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2444.pdf
 $ENDCMP
 #
 $CMP MSP430G2452IN20
-D 20pin PDIP, 8KB Flash Memory, 256B RAM
+D 8kB Flash, 256B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2452IPW14
-D MSP430G2452, 14pin TSSOP, 8KB Flash Memory, 256B RAM
+D 8kB Flash, 256B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2452IPW20
-D MSP430G2452, 20pin TSSOP, 8KB Flash Memory, 256B RAM
+D 8kB Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2452IRSA16
-D MSP430G2452, 16pin QFN, 8KB Flash Memory, 256B RAM
+D 8kB Flash, 256B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2152.pdf
 $ENDCMP
 #
 $CMP MSP430G2453IN20
-D 20pin PDIP, 8KB Flash Memory, 512B RAM
+D 8kB Flash, 512B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
 $ENDCMP
 #
 $CMP MSP430G2453IPW20
-D MSP430G2453, 20pin TSSOP, 8KB Flash Memory, 512B RAM
+D 8kB Flash, 512B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
 $ENDCMP
 #
 $CMP MSP430G2453IPW28
-D MSP430G2453, 28pin TQFP, 8KB Flash Memory, 512B RAM
+D 8kB Flash, 512B RAM, TSSOP-28
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2153.pdf
 $ENDCMP
 #
 $CMP MSP430G2453IRHB32
-D MSP430G2453, 32pin QFN, 8KB Flash Memory, 512B RAM
+D 8kB Flash, 512B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2153.pdf
 $ENDCMP
 #
 $CMP MSP430G2513IN20
-D 20pin PDIP, 16KB Flash Memory, 512B RAM
+D 16kB Flash, 512B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
 $ENDCMP
 #
 $CMP MSP430G2513IPW20
-D MSP430G2513, 20pin TSSOP, 16KB Flash Memory, 512B RAM
+D 16kB Flash, 512B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
 $ENDCMP
 #
 $CMP MSP430G2513IPW28
-D MSP430G2513, 28pin TSSOP, 16KB Flash Memory, 512B RAM
+D 16kB Flash, 512B RAM, TSSOP-28
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2213.pdf
 $ENDCMP
 #
 $CMP MSP430G2513IRHB32
-D MSP430G2513, 32pin QFN, 16KB Flash Memory, 512B RAM
+D 16kB Flash, 512B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2213.pdf
 $ENDCMP
 #
 $CMP MSP430G2533IN20
-D 20pin PDIP, 16KB Flash Memory, 512B RAM
+D 16kB Flash, 512B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
 $ENDCMP
 #
 $CMP MSP430G2533IPW20
-D MSP430G2533, 20pin TSSOP, 16KB Flash Memory, 512B RAM
+D 16kB Flash, 512B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
 $ENDCMP
 #
 $CMP MSP430G2533IPW28
-D MSP430G2533, 28pin TSSOP, 16KB Flash Memory, 512B RAM
+D 16kB Flash, 512B RAM, TSSOP-28
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
 $ENDCMP
 #
 $CMP MSP430G2533IRHB32
-D MSP430G2533, 32pin QFN, 16KB Flash Memory, 512B RAM
+D 16kB Flash, 512B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
 $ENDCMP
 #
 $CMP MSP430G2544IDA38
-D MSP430G2544, 38pin TSSOP, 16KB + 256B Flash Memory, 512B RAM
+D 16kB + 256B Flash, 512B RAM, TSSOP-38
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2444.pdf
 $ENDCMP
 #
 $CMP MSP430G2544IRHA40
-D MSP430G2544, 40pin QFN, 16KB + 256B Flash Memory, 512B RAM
+D 16kB + 256B Flash, 512B RAM, QFN-40
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2444.pdf
 $ENDCMP
 #
 $CMP MSP430G2544IYFF
-D 49ball BGA, 16KB + 256B Flash Memory, 512B RAM
+D 16kB + 256B Flash, 512B RAM, BGA-49
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2444.pdf
 $ENDCMP
 #
 $CMP MSP430G2553IN20
-D MSP430G2553, 20pin PDIP, 16KB Flash Memory, 512B RAM
+D 16kB Flash, 512B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
 $ENDCMP
 #
 $CMP MSP430G2553IPW20
-D MSP430G2553, 20pin TSSOP, 16KB Flash Memory, 512B RAM
+D 16kB Flash, 512B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
 $ENDCMP
 #
 $CMP MSP430G2553IPW28
-D MSP430G2553, 28pin TSSOP, 16KB Flash Memory, 512B RAM
+D 16kB Flash, 512B RAM, TSSOP-28
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
 $ENDCMP
 #
 $CMP MSP430G2553IRHB32
-D MSP430G2553, 32pin QFN, 16KB Flash Memory, 512B RAM
+D 16kB Flash, 512B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
 $ENDCMP
 #
 $CMP MSP430G2744IDA38
-D MSP430G2744, 38pin TSSOP, 32KB + 256B Flash Memory, 1KB RAM
+D 32kB + 256B Flash, 1kB RAM, TSSOP-38
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2444.pdf
 $ENDCMP
 #
 $CMP MSP430G2744IRHA40
-D MSP430G2744, 40pin QFN, 32KB + 256B Flash Memory, 1KB RAM
+D 32kB + 256B Flash, 1kB RAM, QFN-40
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2444.pdf
 $ENDCMP
 #
 $CMP MSP430G2744IYFF
-D 49ball BGA, 32KB + 256B Flash Memory, 1KB RAM
+D 32kB + 256B Flash, 1kB RAM, BGA-49
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2444.pdf
 $ENDCMP
 #
 $CMP MSP430G2755IDA38
-D MSP430F2755, 38pin TSSOP, 32KB Flash Memory, 4KB RAM
+D 32kB Flash, 4kB RAM, TSSOP-38
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2755.pdf
 $ENDCMP
 #
 $CMP MSP430G2755IRHA40
-D MSP430F2755, 40pin QFN, 32KB Flash Memory, 4KB RAM
+D 32kB Flash, 4kB RAM, QFN-40
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2755.pdf
 $ENDCMP
 #
 $CMP MSP430G2855IDA38
-D MSP430F2855, 38pin TSSOP, 48KB Flash Memory, 4KB RAM
+D 48kB Flash, 4kB RAM, TSSOP-38
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2755.pdf
 $ENDCMP
 #
 $CMP MSP430G2855IRHA40
-D MSP430F2855, 40pin QFN, 48KB Flash Memory, 4KB RAM
+D 48kB Flash, 4kB RAM, QFN-40
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2755.pdf
 $ENDCMP
 #
 $CMP MSP430G2955IDA38
-D MSP430F2955, 38pin TSSOP, 56KB Flash Memory, 4KB RAM
+D 56kB Flash, 4kB RAM, TSSOP-38
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2755.pdf
 $ENDCMP
 #
 $CMP MSP430G2955IRHA40
-D MSP430F2955, 40pin QFN, 56KB Flash Memory, 4KB RAM
+D 56kB Flash, 4kB RAM, QFN-40
 K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2755.pdf
 $ENDCMP

--- a/library/MCU_Texas_MSP430.dcm
+++ b/library/MCU_Texas_MSP430.dcm
@@ -3,7 +3,7 @@ EESchema-DOCLIB  Version 2.0
 $CMP MSP430AFE221IPW
 D 4kB Flash, 256B RAM, TSSOP-24
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430afe222.pdf
+F http://www.ti.com/lit/ds/symlink/msp430afe221.pdf
 $ENDCMP
 #
 $CMP MSP430AFE222IPW
@@ -15,43 +15,43 @@ $ENDCMP
 $CMP MSP430AFE223IPW
 D 4kB Flash, 256B RAM, TSSOP-24
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430afe222.pdf
+F http://www.ti.com/lit/ds/symlink/msp430afe223.pdf
 $ENDCMP
 #
 $CMP MSP430AFE231IPW
 D 8kB Flash, 512B RAM, TSSOP-24
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430afe222.pdf
+F http://www.ti.com/lit/ds/symlink/msp430afe231.pdf
 $ENDCMP
 #
 $CMP MSP430AFE232IPW
 D 8kB Flash, 512B RAM, TSSOP-24
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430afe222.pdf
+F http://www.ti.com/lit/ds/symlink/msp430afe232.pdf
 $ENDCMP
 #
 $CMP MSP430AFE233IPW
 D 8kB Flash, 512B RAM, TSSOP-24
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430afe222.pdf
+F http://www.ti.com/lit/ds/symlink/msp430afe233.pdf
 $ENDCMP
 #
 $CMP MSP430AFE251IPW
 D 16kB Flash, 512B RAM, TSSOP-24
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430afe222.pdf
+F http://www.ti.com/lit/ds/symlink/msp430afe251.pdf
 $ENDCMP
 #
 $CMP MSP430AFE252IPW
 D 16kB Flash, 512B RAM, TSSOP-24
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430afe222.pdf
+F http://www.ti.com/lit/ds/symlink/msp430afe252.pdf
 $ENDCMP
 #
 $CMP MSP430AFE253IPW
 D 16kB Flash, 512B RAM, TSSOP-24
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430afe222.pdf
+F http://www.ti.com/lit/ds/symlink/msp430afe253.pdf
 $ENDCMP
 #
 $CMP MSP430F1101AIDGV
@@ -81,49 +81,49 @@ $ENDCMP
 $CMP MSP430F1111AIDGV
 D 2kB + 256B Flash, 128B RAM, TVSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f1101a.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f1111a.pdf
 $ENDCMP
 #
 $CMP MSP430F1111AIDW
 D 2kB + 256B Flash, 128B RAM, SOWB-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f1101a.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f1111a.pdf
 $ENDCMP
 #
 $CMP MSP430F1111AIPW
 D 2kB + 256B Flash, 128B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f1101a.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f1111a.pdf
 $ENDCMP
 #
 $CMP MSP430F1111AIRGE
 D 2kB + 256B Flash, 128B RAM, QFN-24
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f1101a.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f1111a.pdf
 $ENDCMP
 #
 $CMP MSP430F1121AIDGV
 D 4kB + 256B Flash, 256B RAM, TVSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f1101a.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f1121a.pdf
 $ENDCMP
 #
 $CMP MSP430F1121AIDW
 D 4kB + 256B Flash, 256B RAM, SOWB-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f1101a.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f1121a.pdf
 $ENDCMP
 #
 $CMP MSP430F1121AIPW
 D 4kB + 256B Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f1101a.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f1121a.pdf
 $ENDCMP
 #
 $CMP MSP430F1121AIRGE
 D 4kB + 256B Flash, 256B RAM, QFN-24
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f1101a.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f1121a.pdf
 $ENDCMP
 #
 $CMP MSP430F1122IDW
@@ -147,37 +147,37 @@ $ENDCMP
 $CMP MSP430F1132IDW
 D 8kB + 256B Flash, 256B RAM, SOWB-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f1122.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f1132.pdf
 $ENDCMP
 #
 $CMP MSP430F1132IPW
 D 8kB + 256B Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f1122.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f1132.pdf
 $ENDCMP
 #
 $CMP MSP430F1132IRHB
 D 8kB + 256B Flash, 256B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f1122.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f1132.pdf
 $ENDCMP
 #
 $CMP MSP430F1222IDW
 D 4kB + 256B Flash, 256B RAM, SOWB-28
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f1122.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f1222.pdf
 $ENDCMP
 #
 $CMP MSP430F1222IPW
 D 4kB + 256B Flash, 256B RAM, TSSOP-28
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f1122.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f1222.pdf
 $ENDCMP
 #
 $CMP MSP430F1222IRHB
 D 4kB + 256B Flash, 256B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f1122.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f1222.pdf
 $ENDCMP
 #
 $CMP MSP430F122IDW
@@ -195,409 +195,409 @@ $ENDCMP
 $CMP MSP430F122IRHB
 D 4kB + 256B Flash, 256B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f1122.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f122.pdf
 $ENDCMP
 #
 $CMP MSP430F1232IDW
 D 8kB + 256B Flash, 256B RAM, SOWB-28
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f1122.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f1232.pdf
 $ENDCMP
 #
 $CMP MSP430F1232IPW
 D 8kB + 256B Flash, 256B RAM, TSSOP-28
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f1122.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f1232.pdf
 $ENDCMP
 #
 $CMP MSP430F1232IRHB
 D 8kB + 256B Flash, 256B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f1122.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f1232.pdf
 $ENDCMP
 #
 $CMP MSP430F123IDW
 D 8kB + 256B Flash, 256B RAM, SOWB-28
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f122.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f123.pdf
 $ENDCMP
 #
 $CMP MSP430F123IPW
 D 8kB + 256B Flash, 256B RAM, TSSOP-28
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f122.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f123.pdf
 $ENDCMP
 #
 $CMP MSP430F123IRHB
 D 8kB + 256B Flash, 256B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f1122.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f123.pdf
 $ENDCMP
 #
 $CMP MSP430F2001IN
 D 1kB + 256B Flash, 128B RAM, DIP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2001.pdf
 $ENDCMP
 #
 $CMP MSP430F2001IPW
 D 1kB + 256B Flash, 128B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2001.pdf
 $ENDCMP
 #
 $CMP MSP430F2001IRSA
 D 1kB + 256B Flash, 128B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2001.pdf
 $ENDCMP
 #
 $CMP MSP430F2002IN
 D 1kB + 256B Flash, 128B RAM, DIP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2002.pdf
 $ENDCMP
 #
 $CMP MSP430F2002IPW
 D 1kB + 256B Flash, 128B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2002.pdf
 $ENDCMP
 #
 $CMP MSP430F2002IRSA
 D 1kB + 256B Flash, 128B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2002.pdf
 $ENDCMP
 #
 $CMP MSP430F2003IN
 D 1kB + 256B Flash, 128B RAM, DIP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2003.pdf
 $ENDCMP
 #
 $CMP MSP430F2003IPW
 D 1kB + 256B Flash, 128B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2003.pdf
 $ENDCMP
 #
 $CMP MSP430F2003IRSA
 D 1kB + 256B Flash, 128B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2003.pdf
 $ENDCMP
 #
 $CMP MSP430F2011IN
 D 2kB + 256B Flash, 128B RAM, DIP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2011.pdf
 $ENDCMP
 #
 $CMP MSP430F2011IPW
 D 2kB + 256B Flash, 128B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2011.pdf
 $ENDCMP
 #
 $CMP MSP430F2011IRSA
 D 2kB + 256B Flash, 128B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2011.pdf
 $ENDCMP
 #
 $CMP MSP430F2012IN
 D 2kB + 256B Flash, 128B RAM, DIP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2012.pdf
 $ENDCMP
 #
 $CMP MSP430F2012IPW
 D 2kB + 256B Flash, 128B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2012.pdf
 $ENDCMP
 #
 $CMP MSP430F2012IRSA
 D 2kB + 256B Flash, 128B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2012.pdf
 $ENDCMP
 #
 $CMP MSP430F2013IN
 D 2kB + 256B Flash, 128B RAM, DIP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2013.pdf
 $ENDCMP
 #
 $CMP MSP430F2013IPW
 D 2kB + 256B Flash, 128B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2013.pdf
 $ENDCMP
 #
 $CMP MSP430F2013IRSA
 D 2kB + 256B Flash, 128B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2013.pdf
 $ENDCMP
 #
 $CMP MSP430F2101IDGV
 D 1kB + 256B Flash, 128B RAM, TVSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2101.pdf
 $ENDCMP
 #
 $CMP MSP430F2101IDW
 D 1kB + 256B Flash, 128B RAM, SOWB-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2101.pdf
 $ENDCMP
 #
 $CMP MSP430F2101IPW
 D 1kB + 256B Flash, 128B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2101.pdf
 $ENDCMP
 #
 $CMP MSP430F2101IRGE
 D 1kB + 256B Flash, 128B RAM, QFN-24
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2101.pdf
 $ENDCMP
 #
 $CMP MSP430F2111IDGV
 D 2kB + 256B Flash, 128B RAM, TVSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2111.pdf
 $ENDCMP
 #
 $CMP MSP430F2111IDW
 D 2kB + 256B Flash, 128B RAM, SOWB-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2111.pdf
 $ENDCMP
 #
 $CMP MSP430F2111IPW
 D 2kB + 256B Flash, 128B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2111.pdf
 $ENDCMP
 #
 $CMP MSP430F2111IRGE
 D 2kB + 256B Flash, 128B RAM, QFN-24
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2111.pdf
 $ENDCMP
 #
 $CMP MSP430F2112IPW
 D 2kB + 256B Flash, 256B RAM, TSSOP-28
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2112.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2112.pdf
 $ENDCMP
 #
 $CMP MSP430F2112IRHB
 D 2kB + 256B Flash, 256B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2112.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2112.pdf
 $ENDCMP
 #
 $CMP MSP430F2112IRTV
 D 2kB + 256B Flash, 256B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2112.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2112.pdf
 $ENDCMP
 #
 $CMP MSP430F2121IDGV
 D 4kB + 256B Flash, 256B RAM, TVSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2121.pdf
 $ENDCMP
 #
 $CMP MSP430F2121IDW
 D 4kB + 256B Flash, 256B RAM, SOWB-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2121.pdf
 $ENDCMP
 #
 $CMP MSP430F2121IPW
 D 4kB + 256B Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2121.pdf
 $ENDCMP
 #
 $CMP MSP430F2121IRGE
 D 4kB + 256B Flash, 256B RAM, QFN-24
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2121.pdf
 $ENDCMP
 #
 $CMP MSP430F2122IPW
 D 4kB + 256B Flash, 512B RAM, TSSOP-28
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2112.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2122.pdf
 $ENDCMP
 #
 $CMP MSP430F2122IRHB
 D 4kB + 256B Flash, 512B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2112.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2122.pdf
 $ENDCMP
 #
 $CMP MSP430F2122IRTV
 D 4kB + 256B Flash, 512B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2112.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2122.pdf
 $ENDCMP
 #
 $CMP MSP430F2131IDGV
 D 8kB + 256B Flash, 256B RAM, TVSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2131.pdf
 $ENDCMP
 #
 $CMP MSP430F2131IDW
 D 8kB + 256B Flash, 256B RAM, SOWB-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2131.pdf
 $ENDCMP
 #
 $CMP MSP430F2131IPW
 D 8kB + 256B Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2131.pdf
 $ENDCMP
 #
 $CMP MSP430F2131IRGE
 D 8kB + 256B Flash, 256B RAM, QFN-24
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2131.pdf
 $ENDCMP
 #
 $CMP MSP430F2132IPW
 D 8kB + 256B Flash, 512B RAM, TSSOP-28
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2112.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2132.pdf
 $ENDCMP
 #
 $CMP MSP430F2132IRHB
 D 8kB + 256B Flash, 512B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2112.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2132.pdf
 $ENDCMP
 #
 $CMP MSP430F2132IRTV
 D 8kB + 256B Flash, 512B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2112.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2132.pdf
 $ENDCMP
 #
 $CMP MSP430F2232IDA
 D 8kB + 256B Flash, 512B RAM, TSSOP-38
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2232.pdf
 $ENDCMP
 #
 $CMP MSP430F2232IRHA
 D 8kB + 256B Flash, 512B RAM, QFN-40
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2232.pdf
 $ENDCMP
 #
 $CMP MSP430F2232IYFF
 D 8kB + 256B Flash, 512B RAM, BGA-49
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2232.pdf
 $ENDCMP
 #
 $CMP MSP430F2234IDA
 D 8kB + 256B Flash, 512B RAM, TSSOP-38
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2234.pdf
 $ENDCMP
 #
 $CMP MSP430F2234IRHA
 D 8kB + 256B Flash, 512B RAM, QFN-40
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2234.pdf
 $ENDCMP
 #
 $CMP MSP430F2234IYFF
 D 8kB + 256B Flash, 512B RAM, BGA-49
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2234.pdf
 $ENDCMP
 #
 $CMP MSP430F2252IDA
 D 16kB + 256B Flash, 512B RAM, TSSOP-38
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2252.pdf
 $ENDCMP
 #
 $CMP MSP430F2252IRHA
 D 16kB + 256B Flash, 512B RAM, QFN-40
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2252.pdf
 $ENDCMP
 #
 $CMP MSP430F2252IYFF
 D 16kB + 256B Flash, 512B RAM, BGA-49
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2252.pdf
 $ENDCMP
 #
 $CMP MSP430F2254IDA
 D 16kB + 256B Flash, 512B RAM, TSSOP-38
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2254.pdf
 $ENDCMP
 #
 $CMP MSP430F2254IRHA
 D 16kB + 256B Flash, 512B RAM, QFN-40
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2254.pdf
 $ENDCMP
 #
 $CMP MSP430F2254IYFF
 D 16kB + 256B Flash, 512B RAM, BGA-49
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2254.pdf
 $ENDCMP
 #
 $CMP MSP430F2272IDA
 D 32kB + 256B Flash, 1kB RAM, TSSOP-38
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2272.pdf
 $ENDCMP
 #
 $CMP MSP430F2272IRHA
 D 32kB + 256B Flash, 1kB RAM, QFN-40
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2272.pdf
 $ENDCMP
 #
 $CMP MSP430F2272IYFF
 D 32kB + 256B Flash, 1kB RAM, BGA-49
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2272.pdf
 $ENDCMP
 #
 $CMP MSP430F2274IDA
 D 32kB + 256B Flash, 1kB RAM, TSSOP-38
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2274.pdf
 $ENDCMP
 #
 $CMP MSP430F2274IRHA
 D 32kB + 256B Flash, 1kB RAM, QFN-40
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2274.pdf
 $ENDCMP
 #
 $CMP MSP430F2274IYFF
 D 32kB + 256B Flash, 1kB RAM, BGA-49
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2274.pdf
 $ENDCMP
 #
 $CMP MSP430F2330IRHA
@@ -615,49 +615,49 @@ $ENDCMP
 $CMP MSP430F2350IRHA
 D 16kB + 256B Flash, 2kB RAM, QFN-40
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f2330.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2350.pdf
 $ENDCMP
 #
 $CMP MSP430F2350IYFF
 D 16kB + 256B Flash, 2kB RAM, BGA-49
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f2330.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2350.pdf
 $ENDCMP
 #
 $CMP MSP430F2370IRHA
 D 32kB + 256B Flash, 2kB RAM, QFN-40
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f2330.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2370.pdf
 $ENDCMP
 #
 $CMP MSP430F2370IYFF
 D 32kB + 256B Flash, 2kB RAM, BGA-49
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f2330.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f2370.pdf
 $ENDCMP
 #
 $CMP MSP430F5217IRGC
 D 64kB Flash, 8kB RAM, QFN-64
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5227.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5217.pdf
 $ENDCMP
 #
 $CMP MSP430F5217IYFF
 D 64kB Flash, 8kB RAM, BGA-64
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5227.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5217.pdf
 $ENDCMP
 #
 $CMP MSP430F5219IRGC
 D 128kB Flash, 8kB RAM, QFN-64
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5227.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5219.pdf
 $ENDCMP
 #
 $CMP MSP430F5219IYFF
 D 128kB Flash, 8kB RAM, BGA-64
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5227.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5219.pdf
 $ENDCMP
 #
 $CMP MSP430F5227IRGC
@@ -675,37 +675,37 @@ $ENDCMP
 $CMP MSP430F5229IRGC
 D 128kB Flash, 8kB RAM, QFN-64
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5227.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5229.pdf
 $ENDCMP
 #
 $CMP MSP430F5229IYFF
 D 128kB Flash, 8kB RAM, BGA-64
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5227.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5229.pdf
 $ENDCMP
 #
 $CMP MSP430F5232IRGZ
 D 64kB Flash, 8kB RAM, QFN-48
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5242.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5232.pdf
 $ENDCMP
 #
 $CMP MSP430F5234IRGZ
 D 128kB Flash, 8kB RAM, QFN-48
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5242.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5234.pdf
 $ENDCMP
 #
 $CMP MSP430F5237IRGC
 D 64kB Flash, 8kB RAM, QFN-64
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5242.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5237.pdf
 $ENDCMP
 #
 $CMP MSP430F5239IRGC
 D 128kB Flash, 8kB RAM, QFN-64
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5242.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5239.pdf
 $ENDCMP
 #
 $CMP MSP430F5242IRGZ
@@ -717,19 +717,19 @@ $ENDCMP
 $CMP MSP430F5244IRGZ
 D 128kB Flash, 8kB RAM, QFN-48
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5242.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5244.pdf
 $ENDCMP
 #
 $CMP MSP430F5247IRGC
 D 64kB Flash, 8kB RAM, QFN-64
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5242.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5247.pdf
 $ENDCMP
 #
 $CMP MSP430F5249IRGC
 D 128kB Flash, 8kB RAM, QFN-64
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5242.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5249.pdf
 $ENDCMP
 #
 $CMP MSP430F5304IPT
@@ -747,73 +747,73 @@ $ENDCMP
 $CMP MSP430F5308IPT
 D 16kB Flash, 6kB RAM, LQFP-48
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5304.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5308.pdf
 $ENDCMP
 #
 $CMP MSP430F5308IRGC
 D 16kB Flash, 6kB RAM, QFN-64
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5304.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5308.pdf
 $ENDCMP
 #
 $CMP MSP430F5308IRGZ
 D 16kB Flash, 6kB RAM, QFN-48
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5304.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5308.pdf
 $ENDCMP
 #
 $CMP MSP430F5308IZQE
 D 16kB Flash, 6kB RAM, BGA-80
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5304.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5308.pdf
 $ENDCMP
 #
 $CMP MSP430F5309IPT
 D 24kB Flash, 6kB RAM, LQFP-48
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5304.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5309.pdf
 $ENDCMP
 #
 $CMP MSP430F5309IRGC
 D 24kB Flash, 6kB RAM, QFN-64
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5304.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5309.pdf
 $ENDCMP
 #
 $CMP MSP430F5309IRGZ
 D 24kB Flash, 6kB RAM, QFN-48
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5304.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5309.pdf
 $ENDCMP
 #
 $CMP MSP430F5309IZQE
 D 24kB Flash, 6kB RAM, BGA-80
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5304.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5309.pdf
 $ENDCMP
 #
 $CMP MSP430F5310IPT
 D 32kB Flash, 6kB RAM, LQFP-48
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5304.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5310.pdf
 $ENDCMP
 #
 $CMP MSP430F5310IRGC
 D 32kB Flash, 6kB RAM, QFN-64
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5304.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5310.pdf
 $ENDCMP
 #
 $CMP MSP430F5310IRGZ
 D 32kB Flash, 6kB RAM, QFN-48
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5304.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5310.pdf
 $ENDCMP
 #
 $CMP MSP430F5310IZQE
 D 32kB Flash, 6kB RAM, BGA-80
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5304.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5310.pdf
 $ENDCMP
 #
 $CMP MSP430F5333IPZ
@@ -831,37 +831,37 @@ $ENDCMP
 $CMP MSP430F5335IPZ
 D 256kB Flash, 18kB RAM, LQFP-100
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5333.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5335.pdf
 $ENDCMP
 #
 $CMP MSP430F5335IZQW
 D 256kB Flash, 18kB RAM, BGA-113
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5333.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5335.pdf
 $ENDCMP
 #
 $CMP MSP430F5336IPZ
 D 128kB Flash, 18kB RAM, LQFP-100
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5333.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5336.pdf
 $ENDCMP
 #
 $CMP MSP430F5336IZQW
 D 128kB Flash, 18kB RAM, BGA-113
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5333.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5336.pdf
 $ENDCMP
 #
 $CMP MSP430F5338IPZ
 D 256kB Flash, 18kB RAM, LQFP-100
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5333.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5338.pdf
 $ENDCMP
 #
 $CMP MSP430F5338IZQW
 D 128kB Flash, 18kB RAM, BGA-113
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5333.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5338.pdf
 $ENDCMP
 #
 $CMP MSP430F5340IRGZ
@@ -873,13 +873,13 @@ $ENDCMP
 $CMP MSP430F5341IRGZ
 D 96kB Flash, 8kB RAM, QFN-48
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5340.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5341.pdf
 $ENDCMP
 #
 $CMP MSP430F5342IRGZ
 D 128kB Flash, 10kB RAM, QFN-48
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5340.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5342.pdf
 $ENDCMP
 #
 $CMP MSP430F5358IZQW
@@ -891,67 +891,67 @@ $ENDCMP
 $CMP MSP430F5359IZQW
 D 512kB Flash, 66kB RAM, BGA-113
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5358.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5359.pdf
 $ENDCMP
 #
 $CMP MSP430F5500IRGZ
 D 8kB Flash, 4kB + 2kB RAM, QFN-48
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5510.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5500.pdf
 $ENDCMP
 #
 $CMP MSP430F5501IRGZ
 D 16kB Flash, 4kB + 2kB RAM, QFN-48
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5510.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5501.pdf
 $ENDCMP
 #
 $CMP MSP430F5502IRGZ
 D 24kB Flash, 4kB + 2kB RAM, QFN-48
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5510.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5502.pdf
 $ENDCMP
 #
 $CMP MSP430F5503IRGZ
 D 32kB Flash, 4kB + 2kB RAM, QFN-48
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5510.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5503.pdf
 $ENDCMP
 #
 $CMP MSP430F5504IRGZ
 D 8kB Flash, 4kB + 2kB RAM, QFN-48
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5510.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5504.pdf
 $ENDCMP
 #
 $CMP MSP430F5505IRGZ
 D 16kB Flash, 4kB + 2kB RAM, QFN-48
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5510.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5505.pdf
 $ENDCMP
 #
 $CMP MSP430F5506IRGZ
 D 24kB Flash, 4kB + 2kB RAM, QFN-48
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5510.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5506.pdf
 $ENDCMP
 #
 $CMP MSP430F5507IRGZ
 D 32kB Flash, 4kB + 2kB RAM, QFN-48
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5510.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5507.pdf
 $ENDCMP
 #
 $CMP MSP430F5508IRGZ
 D 16kB Flash, 4kB + 2kB RAM, QFN-48
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5510.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5508.pdf
 $ENDCMP
 #
 $CMP MSP430F5509IRGZ
 D 24kB Flash, 4kB + 2kB RAM, QFN-48
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5510.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5509.pdf
 $ENDCMP
 #
 $CMP MSP430F5510IRGZ
@@ -969,13 +969,13 @@ $ENDCMP
 $CMP MSP430F5526IYFF
 D 96kB Flash, 6kB + 2kB RAM, BGA-64
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5524.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5526.pdf
 $ENDCMP
 #
 $CMP MSP430F5528IYFF
 D 128kB Flash, 8kB + 2kB RAM, BGA-64
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5524.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5528.pdf
 $ENDCMP
 #
 $CMP MSP430F5630IZQW
@@ -987,49 +987,49 @@ $ENDCMP
 $CMP MSP430F5631IZQW
 D 192kB Flash, 16kB + 2kB RAM, BGA-113
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5630.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5631.pdf
 $ENDCMP
 #
 $CMP MSP430F5632IZQW
 D 256kB Flash, 16kB + 2kB RAM, BGA-113
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5630.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5632.pdf
 $ENDCMP
 #
 $CMP MSP430F5633IZQW
 D 128kB Flash, 16kB + 2kB RAM, BGA-113
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5630.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5633.pdf
 $ENDCMP
 #
 $CMP MSP430F5634IZQW
 D 192kB Flash, 16kB + 2kB RAM, BGA-113
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5630.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5634.pdf
 $ENDCMP
 #
 $CMP MSP430F5635IZQW
 D 256kB Flash, 16kB + 2kB RAM, BGA-113
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5630.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5635.pdf
 $ENDCMP
 #
 $CMP MSP430F5636IZQW
 D 128kB Flash, 16kB + 2kB RAM, BGA-113
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5630.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5636.pdf
 $ENDCMP
 #
 $CMP MSP430F5637IZQW
 D 192kB Flash, 16kB + 2kB RAM, BGA-113
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5630.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5637.pdf
 $ENDCMP
 #
 $CMP MSP430F5638IZQW
 D 256kB Flash, 16kB + 2kB RAM, BGA-113
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5630.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5638.pdf
 $ENDCMP
 #
 $CMP MSP430F5658IZQW
@@ -1041,7 +1041,7 @@ $ENDCMP
 $CMP MSP430F5659IZQW
 D 512kB Flash, 64kB + 2kB RAM, BGA-113
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430f5658.pdf
+F http://www.ti.com/lit/ds/symlink/msp430f5659.pdf
 $ENDCMP
 #
 $CMP MSP430FR5720IRGE
@@ -1053,133 +1053,133 @@ $ENDCMP
 $CMP MSP430FR5722IRGE
 D 8kB FRAM, 1kB SRAM, QFN-24
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430fr5720.pdf
+F http://www.ti.com/lit/ds/symlink/msp430fr5722.pdf
 $ENDCMP
 #
 $CMP MSP430FR5724IRGE
 D 8kB FRAM, 1kB SRAM, QFN-24
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430fr5720.pdf
+F http://www.ti.com/lit/ds/symlink/msp430fr5724.pdf
 $ENDCMP
 #
 $CMP MSP430FR5726IRGE
 D 16kB FRAM, 1kB SRAM, QFN-24
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430fr5720.pdf
+F http://www.ti.com/lit/ds/symlink/msp430fr5726.pdf
 $ENDCMP
 #
 $CMP MSP430FR5728IRGE
 D 16kB FRAM, 1kB SRAM, QFN-24
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430fr5720.pdf
+F http://www.ti.com/lit/ds/symlink/msp430fr5728.pdf
 $ENDCMP
 #
 $CMP MSP430FR5730IRGE
 D 4kB FRAM, 1kB SRAM, QFN-24
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430fr5720.pdf
+F http://www.ti.com/lit/ds/symlink/msp430fr5730.pdf
 $ENDCMP
 #
 $CMP MSP430FR5732IRGE
 D 8kB FRAM, 1kB SRAM, QFN-24
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430fr5720.pdf
+F http://www.ti.com/lit/ds/symlink/msp430fr5732.pdf
 $ENDCMP
 #
 $CMP MSP430FR5734IRGE
 D 8kB FRAM, 1kB SRAM, QFN-24
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430fr5720.pdf
+F http://www.ti.com/lit/ds/symlink/msp430fr5734.pdf
 $ENDCMP
 #
 $CMP MSP430FR5736IRGE
 D 16kB FRAM, 1kB SRAM, QFN-24
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430fr5720.pdf
+F http://www.ti.com/lit/ds/symlink/msp430fr5736.pdf
 $ENDCMP
 #
 $CMP MSP430FR5738IRGE
 D 16kB FRAM, 1kB SRAM, QFN-24
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430fr5720.pdf
+F http://www.ti.com/lit/ds/symlink/msp430fr5738.pdf
 $ENDCMP
 #
 $CMP MSP430G2001IN14
 D 512B Flash, 128B RAM, DIP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2001.pdf
 $ENDCMP
 #
 $CMP MSP430G2001IPW14
 D 512B Flash, 128B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2001.pdf
 $ENDCMP
 #
 $CMP MSP430G2001IRSA16
 D 512B Flash, 128B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2001.pdf
 $ENDCMP
 #
 $CMP MSP430G2101IN14
 D 1kB Flash, 128B RAM, DIP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2101.pdf
 $ENDCMP
 #
 $CMP MSP430G2101IPW14
 D 1kB Flash, 128B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2101.pdf
 $ENDCMP
 #
 $CMP MSP430G2101IRSA16
 D 1kB Flash, 128B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2101.pdf
 $ENDCMP
 #
 $CMP MSP430G2102IN20
 D 1kB Flash, 128B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2102IPW14
 D 1kB Flash, 128B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2102IPW20
 D 1kB Flash, 128B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2102IRSA16
 D 1kB Flash, 128B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2111IN14
 D 1kB Flash, 128B RAM, DIP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2111.pdf
 $ENDCMP
 #
 $CMP MSP430G2111IPW14
 D 1kB Flash, 128B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2111.pdf
 $ENDCMP
 #
 $CMP MSP430G2111IRSA16
 D 1kB Flash, 128B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2111.pdf
 $ENDCMP
 #
 $CMP MSP430G2112IN20
@@ -1209,85 +1209,85 @@ $ENDCMP
 $CMP MSP430G2113IPW20
 D 1kB Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2153.pdf
 $ENDCMP
 #
 $CMP MSP430G2121IN14
 D 1kB Flash, 128B RAM, DIP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2121.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2121.pdf
 $ENDCMP
 #
 $CMP MSP430G2121IPW14
 D 1kB Flash, 128B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2121.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2121.pdf
 $ENDCMP
 #
 $CMP MSP430G2121IRSA16
 D 1kB Flash, 128B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2121.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2121.pdf
 $ENDCMP
 #
 $CMP MSP430G2131IN14
 D 1kB Flash, 128B RAM, DIP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2121.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2131.pdf
 $ENDCMP
 #
 $CMP MSP430G2131IPW14
 D 1kB Flash, 128B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2121.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2131.pdf
 $ENDCMP
 #
 $CMP MSP430G2131IRSA16
 D 1kB Flash, 128B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2121.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2131.pdf
 $ENDCMP
 #
 $CMP MSP430G2132IN20
 D 1kB Flash, 128B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2132.pdf
 $ENDCMP
 #
 $CMP MSP430G2132IPW14
 D 1kB Flash, 128B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2132.pdf
 $ENDCMP
 #
 $CMP MSP430G2132IPW20
 D 1kB Flash, 128B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2132.pdf
 $ENDCMP
 #
 $CMP MSP430G2132IRSA16
 D 1kB Flash, 128B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2132.pdf
 $ENDCMP
 #
 $CMP MSP430G2152IN20
 D 1kB Flash, 128B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2152.pdf
 $ENDCMP
 #
 $CMP MSP430G2152IPW14
 D 1kB Flash, 128B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2152.pdf
 $ENDCMP
 #
 $CMP MSP430G2152IPW20
 D 1kB Flash, 128B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2152.pdf
 $ENDCMP
 #
 $CMP MSP430G2152IRSA16
@@ -1299,13 +1299,13 @@ $ENDCMP
 $CMP MSP430G2153IN20
 D 1kB Flash, 256B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2153.pdf
 $ENDCMP
 #
 $CMP MSP430G2153IPW20
 D 1kB Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2153.pdf
 $ENDCMP
 #
 $CMP MSP430G2153IPW28
@@ -1323,43 +1323,43 @@ $ENDCMP
 $CMP MSP430G2201IN14
 D 2kB Flash, 128B RAM, DIP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2201.pdf
 $ENDCMP
 #
 $CMP MSP430G2201IPW14
 D 2kB Flash, 128B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2201.pdf
 $ENDCMP
 #
 $CMP MSP430G2201IRSA16
 D 2kB Flash, 128B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2201.pdf
 $ENDCMP
 #
 $CMP MSP430G2202IN20
 D 2kB Flash, 256B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2202.pdf
 $ENDCMP
 #
 $CMP MSP430G2202IPW14
 D 2kB Flash, 256B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2202.pdf
 $ENDCMP
 #
 $CMP MSP430G2202IPW20
 D 2kB Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2202.pdf
 $ENDCMP
 #
 $CMP MSP430G2202IRSA16
 D 2kB Flash, 256B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2202.pdf
 $ENDCMP
 #
 $CMP MSP430G2203IN20
@@ -1395,55 +1395,55 @@ $ENDCMP
 $CMP MSP430G2211IN14
 D 2kB Flash, 128B RAM, DIP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2211.pdf
 $ENDCMP
 #
 $CMP MSP430G2211IPW14
 D 2kB Flash, 128B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2211.pdf
 $ENDCMP
 #
 $CMP MSP430G2211IRSA16
 D 2kB Flash, 128B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2211.pdf
 $ENDCMP
 #
 $CMP MSP430G2212IN20
 D 2kB Flash, 256B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2212.pdf
 $ENDCMP
 #
 $CMP MSP430G2212IPW14
 D 2kB Flash, 256B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2212.pdf
 $ENDCMP
 #
 $CMP MSP430G2212IPW20
 D 2kB Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2212.pdf
 $ENDCMP
 #
 $CMP MSP430G2212IRSA16
 D 2kB Flash, 256B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2212.pdf
 $ENDCMP
 #
 $CMP MSP430G2213IN20
 D 2kB Flash, 256B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2213.pdf
 $ENDCMP
 #
 $CMP MSP430G2213IPW20
 D 2kB Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2213.pdf
 $ENDCMP
 #
 $CMP MSP430G2213IPW28
@@ -1461,67 +1461,67 @@ $ENDCMP
 $CMP MSP430G2221IN14
 D 2kB Flash, 128B RAM, DIP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2121.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2221.pdf
 $ENDCMP
 #
 $CMP MSP430G2221IPW14
 D 2kB Flash, 128B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2121.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2221.pdf
 $ENDCMP
 #
 $CMP MSP430G2221IRSA16
 D 2kB Flash, 128B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2121.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2221.pdf
 $ENDCMP
 #
 $CMP MSP430G2230ID
 D 2kB + 256B Flash, 128B RAM, SOIC-8
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2230.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2230.pdf
 $ENDCMP
 #
 $CMP MSP430G2231IN14
 D 2kB Flash, 128B RAM, DIP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2121.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2231.pdf
 $ENDCMP
 #
 $CMP MSP430G2231IPW14
 D 2kB Flash, 128B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2121.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2231.pdf
 $ENDCMP
 #
 $CMP MSP430G2231IRSA16
 D 2kB Flash, 128B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2121.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2231.pdf
 $ENDCMP
 #
 $CMP MSP430G2232IN20
 D 2kB Flash, 256B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2232.pdf
 $ENDCMP
 #
 $CMP MSP430G2232IPW14
 D 2kB Flash, 256B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2232.pdf
 $ENDCMP
 #
 $CMP MSP430G2232IPW20
 D 2kB Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2232.pdf
 $ENDCMP
 #
 $CMP MSP430G2232IRSA16
 D 2kB Flash, 256B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2232.pdf
 $ENDCMP
 #
 $CMP MSP430G2233IN20
@@ -1551,385 +1551,385 @@ $ENDCMP
 $CMP MSP430G2252IN20
 D 2kB Flash, 256B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2252.pdf
 $ENDCMP
 #
 $CMP MSP430G2252IPW14
 D 2kB Flash, 256B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2252.pdf
 $ENDCMP
 #
 $CMP MSP430G2252IPW20
 D 2kB Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2252.pdf
 $ENDCMP
 #
 $CMP MSP430G2252IRSA16
 D 2kB Flash, 256B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2152.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2252.pdf
 $ENDCMP
 #
 $CMP MSP430G2253IN20
 D 2kB Flash, 256B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2253.pdf
 $ENDCMP
 #
 $CMP MSP430G2253IPW20
 D 2kB Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2253.pdf
 $ENDCMP
 #
 $CMP MSP430G2253IPW28
 D 2kB Flash, 256B RAM, TSSOP-28
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2153.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2253.pdf
 $ENDCMP
 #
 $CMP MSP430G2253IRHB32
 D 2kB Flash, 256B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2153.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2253.pdf
 $ENDCMP
 #
 $CMP MSP430G2302IN20
 D 4kB Flash, 256B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2302.pdf
 $ENDCMP
 #
 $CMP MSP430G2302IPW14
 D 4kB Flash, 256B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2302.pdf
 $ENDCMP
 #
 $CMP MSP430G2302IPW20
 D 4kB Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2302.pdf
 $ENDCMP
 #
 $CMP MSP430G2302IRSA16
 D 4kB Flash, 256B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2302.pdf
 $ENDCMP
 #
 $CMP MSP430G2303IN20
 D 4kB Flash, 256B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2203.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2303.pdf
 $ENDCMP
 #
 $CMP MSP430G2303IPW20
 D 4kB Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2203.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2303.pdf
 $ENDCMP
 #
 $CMP MSP430G2303IPW28
 D 4kB Flash, 256B RAM, TSSOP-28
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2203.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2303.pdf
 $ENDCMP
 #
 $CMP MSP430G2303IRHB32
 D 4kB Flash, 256B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2203.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2303.pdf
 $ENDCMP
 #
 $CMP MSP430G2312IN20
 D 4kB Flash, 256B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2312.pdf
 $ENDCMP
 #
 $CMP MSP430G2312IPW14
 D 4kB Flash, 256B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2312.pdf
 $ENDCMP
 #
 $CMP MSP430G2312IPW20
 D 4kB Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2312.pdf
 $ENDCMP
 #
 $CMP MSP430G2312IRSA16
 D 4kB Flash, 256B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2312.pdf
 $ENDCMP
 #
 $CMP MSP430G2313IN20
 D 4kB Flash, 256B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2313.pdf
 $ENDCMP
 #
 $CMP MSP430G2313IPW20
 D 4kB Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2313.pdf
 $ENDCMP
 #
 $CMP MSP430G2313IPW28
 D 4kB Flash, 256B RAM, TSSOP-28
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2213.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2313.pdf
 $ENDCMP
 #
 $CMP MSP430G2313IRHB32
 D 4kB Flash, 256B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2213.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2313.pdf
 $ENDCMP
 #
 $CMP MSP430G2332IN20
 D 4kB Flash, 256B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2332.pdf
 $ENDCMP
 #
 $CMP MSP430G2332IPW14
 D 4kB Flash, 256B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2332.pdf
 $ENDCMP
 #
 $CMP MSP430G2332IPW20
 D 4kB Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2332.pdf
 $ENDCMP
 #
 $CMP MSP430G2332IRSA16
 D 4kB Flash, 256B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2332.pdf
 $ENDCMP
 #
 $CMP MSP430G2333IN20
 D 4kB Flash, 256B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2333.pdf
 $ENDCMP
 #
 $CMP MSP430G2333IPW20
 D 4kB Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2333.pdf
 $ENDCMP
 #
 $CMP MSP430G2333IPW28
 D 4kB Flash, 256B RAM, TSSOP-28
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2333.pdf
 $ENDCMP
 #
 $CMP MSP430G2333IRHB32
 D 4kB Flash, 256B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2333.pdf
 $ENDCMP
 #
 $CMP MSP430G2352IN20
 D 4kB Flash, 256B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2352.pdf
 $ENDCMP
 #
 $CMP MSP430G2352IPW14
 D 4kB Flash, 256B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2352.pdf
 $ENDCMP
 #
 $CMP MSP430G2352IPW20
 D 4kB Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2352.pdf
 $ENDCMP
 #
 $CMP MSP430G2352IRSA16
 D 4kB Flash, 256B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2152.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2352.pdf
 $ENDCMP
 #
 $CMP MSP430G2353IN20
 D 4kB Flash, 256B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2353.pdf
 $ENDCMP
 #
 $CMP MSP430G2353IPW20
 D 4kB Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2353.pdf
 $ENDCMP
 #
 $CMP MSP430G2353IPW28
 D 4kB Flash, 256B RAM, TSSOP-28
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2153.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2353.pdf
 $ENDCMP
 #
 $CMP MSP430G2353IRHB32
 D 4kB Flash, 256B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2153.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2353.pdf
 $ENDCMP
 #
 $CMP MSP430G2402IN20
 D 8kB Flash, 256B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2402.pdf
 $ENDCMP
 #
 $CMP MSP430G2402IPW14
 D 8kB Flash, 256B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2402.pdf
 $ENDCMP
 #
 $CMP MSP430G2402IPW20
 D 8kB Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2402.pdf
 $ENDCMP
 #
 $CMP MSP430G2402IRSA16
 D 8kB Flash, 256B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2402.pdf
 $ENDCMP
 #
 $CMP MSP430G2403IN20
 D 8kB Flash, 512B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2203.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2403.pdf
 $ENDCMP
 #
 $CMP MSP430G2403IPW20
 D 8kB Flash, 512B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2203.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2403.pdf
 $ENDCMP
 #
 $CMP MSP430G2403IPW28
 D 8kB Flash, 512B RAM, TSSOP-28
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2203.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2403.pdf
 $ENDCMP
 #
 $CMP MSP430G2403IRHB32
 D 8kB Flash, 512B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2203.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2403.pdf
 $ENDCMP
 #
 $CMP MSP430G2412IN20
 D 8kB Flash, 256B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2412.pdf
 $ENDCMP
 #
 $CMP MSP430G2412IPW14
 D 8kB Flash, 256B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2412.pdf
 $ENDCMP
 #
 $CMP MSP430G2412IPW20
 D 8kB Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2412.pdf
 $ENDCMP
 #
 $CMP MSP430G2412IRSA16
 D 8kB Flash, 256B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2412.pdf
 $ENDCMP
 #
 $CMP MSP430G2413IN20
 D 8kB Flash, 512B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2413.pdf
 $ENDCMP
 #
 $CMP MSP430G2413IPW20
 D 8kB Flash, 512B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2413.pdf
 $ENDCMP
 #
 $CMP MSP430G2413IPW28
 D 8kB Flash, 512B RAM, TSSOP-28
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2213.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2413.pdf
 $ENDCMP
 #
 $CMP MSP430G2413IRHB32
 D 8kB Flash, 512B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2213.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2413.pdf
 $ENDCMP
 #
 $CMP MSP430G2432IN20
 D 8kB Flash, 256B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2432.pdf
 $ENDCMP
 #
 $CMP MSP430G2432IPW14
 D 8kB Flash, 256B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2432.pdf
 $ENDCMP
 #
 $CMP MSP430G2432IPW20
 D 8kB Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2432.pdf
 $ENDCMP
 #
 $CMP MSP430G2432IRSA16
 D 8kB Flash, 256B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
-F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2432.pdf
 $ENDCMP
 #
 $CMP MSP430G2433IN20
 D 8kB Flash, 512B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2433.pdf
 $ENDCMP
 #
 $CMP MSP430G2433IPW20
 D 8kB Flash, 512B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2433.pdf
 $ENDCMP
 #
 $CMP MSP430G2433IPW28
 D 8kB Flash, 512B RAM, TSSOP-28
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2433.pdf
 $ENDCMP
 #
 $CMP MSP430G2433IRHB32
 D 8kB Flash, 512B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2433.pdf
 $ENDCMP
 #
 $CMP MSP430G2444IDA38
@@ -1953,115 +1953,115 @@ $ENDCMP
 $CMP MSP430G2452IN20
 D 8kB Flash, 256B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2452.pdf
 $ENDCMP
 #
 $CMP MSP430G2452IPW14
 D 8kB Flash, 256B RAM, TSSOP-14
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2452.pdf
 $ENDCMP
 #
 $CMP MSP430G2452IPW20
 D 8kB Flash, 256B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2452.pdf
 $ENDCMP
 #
 $CMP MSP430G2452IRSA16
 D 8kB Flash, 256B RAM, QFN-16
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2152.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2452.pdf
 $ENDCMP
 #
 $CMP MSP430G2453IN20
 D 8kB Flash, 512B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2453.pdf
 $ENDCMP
 #
 $CMP MSP430G2453IPW20
 D 8kB Flash, 512B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2453.pdf
 $ENDCMP
 #
 $CMP MSP430G2453IPW28
 D 8kB Flash, 512B RAM, TSSOP-28
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2153.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2453.pdf
 $ENDCMP
 #
 $CMP MSP430G2453IRHB32
 D 8kB Flash, 512B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2153.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2453.pdf
 $ENDCMP
 #
 $CMP MSP430G2513IN20
 D 16kB Flash, 512B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2513.pdf
 $ENDCMP
 #
 $CMP MSP430G2513IPW20
 D 16kB Flash, 512B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2513.pdf
 $ENDCMP
 #
 $CMP MSP430G2513IPW28
 D 16kB Flash, 512B RAM, TSSOP-28
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2213.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2513.pdf
 $ENDCMP
 #
 $CMP MSP430G2513IRHB32
 D 16kB Flash, 512B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2213.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2513.pdf
 $ENDCMP
 #
 $CMP MSP430G2533IN20
 D 16kB Flash, 512B RAM, DIP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2533.pdf
 $ENDCMP
 #
 $CMP MSP430G2533IPW20
 D 16kB Flash, 512B RAM, TSSOP-20
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2533.pdf
 $ENDCMP
 #
 $CMP MSP430G2533IPW28
 D 16kB Flash, 512B RAM, TSSOP-28
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2533.pdf
 $ENDCMP
 #
 $CMP MSP430G2533IRHB32
 D 16kB Flash, 512B RAM, QFN-32
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2533.pdf
 $ENDCMP
 #
 $CMP MSP430G2544IDA38
 D 16kB + 256B Flash, 512B RAM, TSSOP-38
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2444.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2544.pdf
 $ENDCMP
 #
 $CMP MSP430G2544IRHA40
 D 16kB + 256B Flash, 512B RAM, QFN-40
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2444.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2544.pdf
 $ENDCMP
 #
 $CMP MSP430G2544IYFF
 D 16kB + 256B Flash, 512B RAM, BGA-49
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2444.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2544.pdf
 $ENDCMP
 #
 $CMP MSP430G2553IN20
@@ -2091,19 +2091,19 @@ $ENDCMP
 $CMP MSP430G2744IDA38
 D 32kB + 256B Flash, 1kB RAM, TSSOP-38
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2444.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2744.pdf
 $ENDCMP
 #
 $CMP MSP430G2744IRHA40
 D 32kB + 256B Flash, 1kB RAM, QFN-40
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2444.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2744.pdf
 $ENDCMP
 #
 $CMP MSP430G2744IYFF
 D 32kB + 256B Flash, 1kB RAM, BGA-49
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2444.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2744.pdf
 $ENDCMP
 #
 $CMP MSP430G2755IDA38
@@ -2121,25 +2121,25 @@ $ENDCMP
 $CMP MSP430G2855IDA38
 D 48kB Flash, 4kB RAM, TSSOP-38
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2755.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2855.pdf
 $ENDCMP
 #
 $CMP MSP430G2855IRHA40
 D 48kB Flash, 4kB RAM, QFN-40
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2755.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2855.pdf
 $ENDCMP
 #
 $CMP MSP430G2955IDA38
 D 56kB Flash, 4kB RAM, TSSOP-38
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2755.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2955.pdf
 $ENDCMP
 #
 $CMP MSP430G2955IRHA40
 D 56kB Flash, 4kB RAM, QFN-40
 K TI MSP430 16-bit mixed signal microcontroller
-F http://www.ti.com/lit/ds/symlink/msp430g2755.pdf
+F http://www.ti.com/lit/ds/symlink/msp430g2955.pdf
 $ENDCMP
 #
 #End Doc Library

--- a/library/MCU_Texas_MSP430.dcm
+++ b/library/MCU_Texas_MSP430.dcm
@@ -2,2143 +2,2143 @@ EESchema-DOCLIB  Version 2.0
 #
 $CMP MSP430AFE221IPW
 D 24pin TSSOP, 4KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430afe222.pdf
 $ENDCMP
 #
 $CMP MSP430AFE222IPW
 D 24pin TSSOP, 4KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430afe222.pdf
 $ENDCMP
 #
 $CMP MSP430AFE223IPW
 D 24pin TSSOP, 4KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430afe222.pdf
 $ENDCMP
 #
 $CMP MSP430AFE231IPW
 D 24pin TSSOP, 8KB Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430afe222.pdf
 $ENDCMP
 #
 $CMP MSP430AFE232IPW
 D 24pin TSSOP, 8KB Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430afe222.pdf
 $ENDCMP
 #
 $CMP MSP430AFE233IPW
 D 24pin TSSOP, 8KB Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430afe222.pdf
 $ENDCMP
 #
 $CMP MSP430AFE251IPW
 D 24pin TSSOP, 16KB Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430afe222.pdf
 $ENDCMP
 #
 $CMP MSP430AFE252IPW
 D 24pin TSSOP, 16KB Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430afe222.pdf
 $ENDCMP
 #
 $CMP MSP430AFE253IPW
 D 24pin TSSOP, 16KB Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430afe222.pdf
 $ENDCMP
 #
 $CMP MSP430F1101AIDGV
 D 20pin TVSOP, 1KB + 128B Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1101a.pdf
 $ENDCMP
 #
 $CMP MSP430F1101AIDW
 D 20pin SOWB, 1KB + 128B Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1101a.pdf
 $ENDCMP
 #
 $CMP MSP430F1101AIPW
 D 20pin TSSOP, 1KB + 128B Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1101a.pdf
 $ENDCMP
 #
 $CMP MSP430F1101AIRGE
 D 24pin QFN, 1KB + 128B Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1101a.pdf
 $ENDCMP
 #
 $CMP MSP430F1111AIDGV
 D 20pin TVSOP, 2KB + 256B Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1101a.pdf
 $ENDCMP
 #
 $CMP MSP430F1111AIDW
 D 20pin SOWB, 2KB + 256B Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1101a.pdf
 $ENDCMP
 #
 $CMP MSP430F1111AIPW
 D 20pin TSSOP, 2KB + 256B Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1101a.pdf
 $ENDCMP
 #
 $CMP MSP430F1111AIRGE
 D 24pin QFN, 2KB + 256B Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1101a.pdf
 $ENDCMP
 #
 $CMP MSP430F1121AIDGV
 D 20pin TVSOP, 4KB + 256B Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1101a.pdf
 $ENDCMP
 #
 $CMP MSP430F1121AIDW
 D 20pin SOWB, 4KB + 256B Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1101a.pdf
 $ENDCMP
 #
 $CMP MSP430F1121AIPW
 D 20pin TSSOP, 4KB + 256B Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1101a.pdf
 $ENDCMP
 #
 $CMP MSP430F1121AIRGE
 D 24pin QFN, 4KB + 256B Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1101a.pdf
 $ENDCMP
 #
 $CMP MSP430F1122IDW
 D 20pin SOWB, 4KB + 256B Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1122.pdf
 $ENDCMP
 #
 $CMP MSP430F1122IPW
 D 20pin TSSOP, 4KB + 256B Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1122.pdf
 $ENDCMP
 #
 $CMP MSP430F1122IRHB
 D 32pin QFN, 4KB + 256B Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1122.pdf
 $ENDCMP
 #
 $CMP MSP430F1132IDW
 D 20pin SOWB, 8KB + 256B Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1122.pdf
 $ENDCMP
 #
 $CMP MSP430F1132IPW
 D 20pin TSSOP, 8KB + 256B Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1122.pdf
 $ENDCMP
 #
 $CMP MSP430F1132IRHB
 D 32pin QFN, 8KB + 256B Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1122.pdf
 $ENDCMP
 #
 $CMP MSP430F1222IDW
 D 28pin SOWB, 4KB + 256B Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1122.pdf
 $ENDCMP
 #
 $CMP MSP430F1222IPW
 D 28pin TSSOP, 4KB + 256B Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1122.pdf
 $ENDCMP
 #
 $CMP MSP430F1222IRHB
 D 32pin QFN, 4KB + 256B Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1122.pdf
 $ENDCMP
 #
 $CMP MSP430F122IDW
 D 28pin SOWB, 4KB + 256B Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f122.pdf
 $ENDCMP
 #
 $CMP MSP430F122IPW
 D 28pin TSSOP, 4KB + 256B Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f122.pdf
 $ENDCMP
 #
 $CMP MSP430F122IRHB
 D 32pin QFN, 4KB + 256B Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1122.pdf
 $ENDCMP
 #
 $CMP MSP430F1232IDW
 D 28pin SOWB, 8KB + 256B Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1122.pdf
 $ENDCMP
 #
 $CMP MSP430F1232IPW
 D 28pin TSSOP, 8KB + 256B Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1122.pdf
 $ENDCMP
 #
 $CMP MSP430F1232IRHB
 D 32pin QFN, 8KB + 256B Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1122.pdf
 $ENDCMP
 #
 $CMP MSP430F123IDW
 D 28pin SOWB, 8KB + 256B Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f122.pdf
 $ENDCMP
 #
 $CMP MSP430F123IPW
 D 28pin TSSOP, 8KB + 256B Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f122.pdf
 $ENDCMP
 #
 $CMP MSP430F123IRHB
 D 32pin QFN, 8KB + 256B Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f1122.pdf
 $ENDCMP
 #
 $CMP MSP430F2001IN
 D 14pin PDIP, 1KB + 256B Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
 $ENDCMP
 #
 $CMP MSP430F2001IPW
 D 14pin TSSOP, 1KB + 256B Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
 $ENDCMP
 #
 $CMP MSP430F2001IRSA
 D 16pin QFN, 1KB + 256B Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
 $ENDCMP
 #
 $CMP MSP430F2002IN
 D 14pin PDIP, 1KB + 256B Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
 $ENDCMP
 #
 $CMP MSP430F2002IPW
 D 14pin TSSOP, 1KB + 256B Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
 $ENDCMP
 #
 $CMP MSP430F2002IRSA
 D 16pin QFN, 1KB + 256B Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
 $ENDCMP
 #
 $CMP MSP430F2003IN
 D 14pin PDIP, 1KB + 256B Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
 $ENDCMP
 #
 $CMP MSP430F2003IPW
 D 14pin TSSOP, 1KB + 256B Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
 $ENDCMP
 #
 $CMP MSP430F2003IRSA
 D 16pin QFN, 1KB + 256B Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
 $ENDCMP
 #
 $CMP MSP430F2011IN
 D 14pin PDIP, 2KB + 256B Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
 $ENDCMP
 #
 $CMP MSP430F2011IPW
 D 14pin TSSOP, 2KB + 256B Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
 $ENDCMP
 #
 $CMP MSP430F2011IRSA
 D 16pin QFN, 2KB + 256B Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
 $ENDCMP
 #
 $CMP MSP430F2012IN
 D 14pin PDIP, 2KB + 256B Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
 $ENDCMP
 #
 $CMP MSP430F2012IPW
 D 14pin TSSOP, 2KB + 256B Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
 $ENDCMP
 #
 $CMP MSP430F2012IRSA
 D 16pin QFN, 2KB + 256B Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
 $ENDCMP
 #
 $CMP MSP430F2013IN
 D 14pin PDIP, 2KB + 256B Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
 $ENDCMP
 #
 $CMP MSP430F2013IPW
 D 14pin TSSOP, 2KB + 256B Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
 $ENDCMP
 #
 $CMP MSP430F2013IRSA
 D 16pin QFN, 2KB + 256B Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2001.pdf
 $ENDCMP
 #
 $CMP MSP430F2101IDGV
 D 20pin TVSOP, 1KB + 256B Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
 $ENDCMP
 #
 $CMP MSP430F2101IDW
 D 20pin SOWB, 1KB + 256B Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
 $ENDCMP
 #
 $CMP MSP430F2101IPW
 D 20pin TSSOP, 1KB + 256B Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
 $ENDCMP
 #
 $CMP MSP430F2101IRGE
 D 24pin QFN, 1KB + 256B Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
 $ENDCMP
 #
 $CMP MSP430F2111IDGV
 D 20pin TVSOP, 2KB + 256B Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
 $ENDCMP
 #
 $CMP MSP430F2111IDW
 D 20pin SOWB, 2KB + 256B Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
 $ENDCMP
 #
 $CMP MSP430F2111IPW
 D 20pin TSSOP, 2KB + 256B Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
 $ENDCMP
 #
 $CMP MSP430F2111IRGE
 D 24pin QFN, 2KB + 256B Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
 $ENDCMP
 #
 $CMP MSP430F2112IPW
 D 28pin TSSOP, 2KB + 256B Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2112.pdf
 $ENDCMP
 #
 $CMP MSP430F2112IRHB
 D 32pin QFN, 2KB + 256B Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2112.pdf
 $ENDCMP
 #
 $CMP MSP430F2112IRTV
 D 32pin QFN, 2KB + 256B Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2112.pdf
 $ENDCMP
 #
 $CMP MSP430F2121IDGV
 D 20pin TVSOP, 4KB + 256B Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
 $ENDCMP
 #
 $CMP MSP430F2121IDW
 D 20pin SOWB, 4KB + 256B Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
 $ENDCMP
 #
 $CMP MSP430F2121IPW
 D 20pin TSSOP, 4KB + 256B Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
 $ENDCMP
 #
 $CMP MSP430F2121IRGE
 D 24pin QFN, 4KB + 256B Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
 $ENDCMP
 #
 $CMP MSP430F2122IPW
 D 28pin TSSOP, 4KB + 256B Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2112.pdf
 $ENDCMP
 #
 $CMP MSP430F2122IRHB
 D 32pin QFN, 4KB + 256B Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2112.pdf
 $ENDCMP
 #
 $CMP MSP430F2122IRTV
 D 32pin QFN, 4KB + 256B Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2112.pdf
 $ENDCMP
 #
 $CMP MSP430F2131IDGV
 D 20pin TVSOP, 8KB + 256B Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
 $ENDCMP
 #
 $CMP MSP430F2131IDW
 D 20pin SOWB, 8KB + 256B Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
 $ENDCMP
 #
 $CMP MSP430F2131IPW
 D 20pin TSSOP, 8KB + 256B Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
 $ENDCMP
 #
 $CMP MSP430F2131IRGE
 D 24pin QFN, 8KB + 256B Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2101.pdf
 $ENDCMP
 #
 $CMP MSP430F2132IPW
 D 28pin TSSOP, 8KB + 256B Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2112.pdf
 $ENDCMP
 #
 $CMP MSP430F2132IRHB
 D 32pin QFN, 8KB + 256B Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2112.pdf
 $ENDCMP
 #
 $CMP MSP430F2132IRTV
 D 32pin QFN, 8KB + 256B Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2112.pdf
 $ENDCMP
 #
 $CMP MSP430F2232IDA
 D 38pin TSSOP, 8KB + 256B Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
 $ENDCMP
 #
 $CMP MSP430F2232IRHA
 D 40pin QFN, 8KB + 256B Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
 $ENDCMP
 #
 $CMP MSP430F2232IYFF
 D 49ball BGA, 8KB + 256B Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
 $ENDCMP
 #
 $CMP MSP430F2234IDA
 D 38pin TSSOP, 8KB + 256B Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
 $ENDCMP
 #
 $CMP MSP430F2234IRHA
 D 40pin QFN, 8KB + 256B Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
 $ENDCMP
 #
 $CMP MSP430F2234IYFF
 D 49ball BGA, 8KB + 256B Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
 $ENDCMP
 #
 $CMP MSP430F2252IDA
 D 38pin TSSOP, 16KB + 256B Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
 $ENDCMP
 #
 $CMP MSP430F2252IRHA
 D 40pin QFN, 16KB + 256B Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
 $ENDCMP
 #
 $CMP MSP430F2252IYFF
 D 49ball BGA, 16KB + 256B Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
 $ENDCMP
 #
 $CMP MSP430F2254IDA
 D 38pin TSSOP, 16KB + 256B Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
 $ENDCMP
 #
 $CMP MSP430F2254IRHA
 D 40pin QFN, 16KB + 256B Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
 $ENDCMP
 #
 $CMP MSP430F2254IYFF
 D 49ball BGA, 16KB + 256B Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
 $ENDCMP
 #
 $CMP MSP430F2272IDA
 D 38pin TSSOP, 32KB + 256B Flash Memory, 1KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
 $ENDCMP
 #
 $CMP MSP430F2272IRHA
 D 40pin QFN, 32KB + 256B Flash Memory, 1KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
 $ENDCMP
 #
 $CMP MSP430F2272IYFF
 D 49ball BGA, 32KB + 256B Flash Memory, 1KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
 $ENDCMP
 #
 $CMP MSP430F2274IDA
 D 38pin TSSOP, 32KB + 256B Flash Memory, 1KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
 $ENDCMP
 #
 $CMP MSP430F2274IRHA
 D 40pin QFN, 32KB + 256B Flash Memory, 1KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
 $ENDCMP
 #
 $CMP MSP430F2274IYFF
 D 49ball BGA, 32KB + 256B Flash Memory, 1KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430f2232.pdf
 $ENDCMP
 #
 $CMP MSP430F2330IRHA
 D 40pin QFN, 8KB + 256B Flash Memory, 1KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f2330.pdf
 $ENDCMP
 #
 $CMP MSP430F2330IYFF
 D 49ball BGA, 8KB + 256B Flash Memory, 1KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f2330.pdf
 $ENDCMP
 #
 $CMP MSP430F2350IRHA
 D MSP430F2340, 40pin QFN, 16KB + 256B Flash Memory, 2KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f2330.pdf
 $ENDCMP
 #
 $CMP MSP430F2350IYFF
 D 49ball BGA, 16KB + 256B Flash Memory, 2KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f2330.pdf
 $ENDCMP
 #
 $CMP MSP430F2370IRHA
 D 40pin QFN, 32KB + 256B Flash Memory, 2KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f2330.pdf
 $ENDCMP
 #
 $CMP MSP430F2370IYFF
 D 49ball BGA, 32KB + 256B Flash Memory, 2KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f2330.pdf
 $ENDCMP
 #
 $CMP MSP430F5217IRGC
 D 64pin QFN, 64KB Flash Memory, 8KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5227.pdf
 $ENDCMP
 #
 $CMP MSP430F5217IYFF
 D 64ball BGA, 64KB Flash Memory, 8KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5227.pdf
 $ENDCMP
 #
 $CMP MSP430F5219IRGC
 D 64pin QFN, 128KB Flash Memory, 8KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5227.pdf
 $ENDCMP
 #
 $CMP MSP430F5219IYFF
 D 64ball BGA, 128KB Flash Memory, 8KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5227.pdf
 $ENDCMP
 #
 $CMP MSP430F5227IRGC
 D 64pin QFN, 64KB Flash Memory, 8KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5227.pdf
 $ENDCMP
 #
 $CMP MSP430F5227IYFF
 D 64ball BGA, 64KB Flash Memory, 8KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5227.pdf
 $ENDCMP
 #
 $CMP MSP430F5229IRGC
 D 64pin QFN, 128KB Flash Memory, 8KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5227.pdf
 $ENDCMP
 #
 $CMP MSP430F5229IYFF
 D 64ball BGA, 128KB Flash Memory, 8KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5227.pdf
 $ENDCMP
 #
 $CMP MSP430F5232IRGZ
 D MSP430F2532, 48pin QFN, 64KB Flash Memory, 8KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5242.pdf
 $ENDCMP
 #
 $CMP MSP430F5234IRGZ
 D MSP430F2534, 48pin QFN, 128KB Flash Memory, 8KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5242.pdf
 $ENDCMP
 #
 $CMP MSP430F5237IRGC
 D 64pin QFN, 64KB Flash Memory, 8KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5242.pdf
 $ENDCMP
 #
 $CMP MSP430F5239IRGC
 D 64pin QFN, 128KB Flash Memory, 8KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5242.pdf
 $ENDCMP
 #
 $CMP MSP430F5242IRGZ
 D MSP430F2542, 48pin QFN, 64KB Flash Memory, 8KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5242.pdf
 $ENDCMP
 #
 $CMP MSP430F5244IRGZ
 D MSP430F2544, 48pin QFN, 128KB Flash Memory, 8KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5242.pdf
 $ENDCMP
 #
 $CMP MSP430F5247IRGC
 D 64pin QFN, 64KB Flash Memory, 8KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5242.pdf
 $ENDCMP
 #
 $CMP MSP430F5249IRGC
 D 64pin QFN, 128KB Flash Memory, 8KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5242.pdf
 $ENDCMP
 #
 $CMP MSP430F5304IPT
 D 48pin LQFN, 8KB Flash Memory, 6KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5304.pdf
 $ENDCMP
 #
 $CMP MSP430F5304IRGZ
 D 48pin QFN, 8KB Flash Memory, 6KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5304.pdf
 $ENDCMP
 #
 $CMP MSP430F5308IPT
 D 48pin LQFN, 16KB Flash Memory, 6KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5304.pdf
 $ENDCMP
 #
 $CMP MSP430F5308IRGC
 D 64pin QFN, 16KB Flash Memory, 6KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5304.pdf
 $ENDCMP
 #
 $CMP MSP430F5308IRGZ
 D 48pin LQFN, 16KB Flash Memory, 6KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5304.pdf
 $ENDCMP
 #
 $CMP MSP430F5308IZQE
 D 80ball BGA, 16KB Flash Memory, 6KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5304.pdf
 $ENDCMP
 #
 $CMP MSP430F5309IPT
 D 48pin LQFN, 24KB Flash Memory, 6KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5304.pdf
 $ENDCMP
 #
 $CMP MSP430F5309IRGC
 D 64pin QFN, 24KB Flash Memory, 6KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5304.pdf
 $ENDCMP
 #
 $CMP MSP430F5309IRGZ
 D 48pin QFN, 24KB Flash Memory, 6KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5304.pdf
 $ENDCMP
 #
 $CMP MSP430F5309IZQE
 D 80ball BGA, 24KB Flash Memory, 6KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5304.pdf
 $ENDCMP
 #
 $CMP MSP430F5310IPT
 D 48pin LQFN, 32KB Flash Memory, 6KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5304.pdf
 $ENDCMP
 #
 $CMP MSP430F5310IRGC
 D 64pin QFN, 32KB Flash Memory, 6KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5304.pdf
 $ENDCMP
 #
 $CMP MSP430F5310IRGZ
 D 48pin QFN, 32KB Flash Memory, 6KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5304.pdf
 $ENDCMP
 #
 $CMP MSP430F5310IZQE
 D 80ball BGA, 32KB Flash Memory, 6KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5304.pdf
 $ENDCMP
 #
 $CMP MSP430F5333IPZ
 D 100pin VQFP, 128KB Flash Memory, 18KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5333.pdf
 $ENDCMP
 #
 $CMP MSP430F5333IZQW
 D 113ball BGA, 128KB Flash Memory, 18KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5333.pdf
 $ENDCMP
 #
 $CMP MSP430F5335IPZ
 D 100pin VQFP, 256KB Flash Memory, 18KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5333.pdf
 $ENDCMP
 #
 $CMP MSP430F5335IZQW
 D 113ball BGA, 256KB Flash Memory, 18KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5333.pdf
 $ENDCMP
 #
 $CMP MSP430F5336IPZ
 D 100pin VQFP, 128KB Flash Memory, 18KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5333.pdf
 $ENDCMP
 #
 $CMP MSP430F5336IZQW
 D 113ball BGA, 128KB Flash Memory, 18KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5333.pdf
 $ENDCMP
 #
 $CMP MSP430F5338IPZ
 D 100pin VQFP, 256KB Flash Memory, 18KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5333.pdf
 $ENDCMP
 #
 $CMP MSP430F5338IZQW
 D 113ball BGA, 128KB Flash Memory, 18KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5333.pdf
 $ENDCMP
 #
 $CMP MSP430F5340IRGZ
 D 48pin QFN, 64KB Flash Memory, 6KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5340.pdf
 $ENDCMP
 #
 $CMP MSP430F5341IRGZ
 D 48pin QFN, 96KB Flash Memory, 8KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5340.pdf
 $ENDCMP
 #
 $CMP MSP430F5342IRGZ
 D MSP430F5340, 48pin QFN, 128KB Flash Memory, 10KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5340.pdf
 $ENDCMP
 #
 $CMP MSP430F5358IZQW
 D 113ball BGA, 384KB Flash Memory, 34KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5358.pdf
 $ENDCMP
 #
 $CMP MSP430F5359IZQW
 D 113ball BGA, 512KB Flash Memory, 66KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5358.pdf
 $ENDCMP
 #
 $CMP MSP430F5500IRGZ
 D 48pin QFN, 8KB Flash Memory, 4 + 2KB SRAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5510.pdf
 $ENDCMP
 #
 $CMP MSP430F5501IRGZ
 D 48pin QFN, 16KB Flash Memory, 4 + 2KB SRAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5510.pdf
 $ENDCMP
 #
 $CMP MSP430F5502IRGZ
 D 48pin QFN, 24KB Flash Memory, 4 + 2KB SRAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5510.pdf
 $ENDCMP
 #
 $CMP MSP430F5503IRGZ
 D 48pin QFN, 32KB Flash Memory, 4 + 2KB SRAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5510.pdf
 $ENDCMP
 #
 $CMP MSP430F5504IRGZ
 D 48pin QFN, 8KB Flash Memory, 4 + 2KB SRAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5510.pdf
 $ENDCMP
 #
 $CMP MSP430F5505IRGZ
 D 48pin QFN, 16KB Flash Memory, 4 + 2KB SRAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5510.pdf
 $ENDCMP
 #
 $CMP MSP430F5506IRGZ
 D 48pin QFN, 24KB Flash Memory, 4 + 2KB SRAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5510.pdf
 $ENDCMP
 #
 $CMP MSP430F5507IRGZ
 D 48pin QFN, 32KB Flash Memory, 4 + 2KB SRAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5510.pdf
 $ENDCMP
 #
 $CMP MSP430F5508IRGZ
 D 48pin QFN, 16KB Flash Memory, 4 + 2KB SRAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5510.pdf
 $ENDCMP
 #
 $CMP MSP430F5509IRGZ
 D 48pin QFN, 24KB Flash Memory, 4 + 2KB SRAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5510.pdf
 $ENDCMP
 #
 $CMP MSP430F5510IRGZ
 D 48pin QFN, 32KB Flash Memory, 4 + 2KB SRAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5510.pdf
 $ENDCMP
 #
 $CMP MSP430F5524IYFF
 D 64ball BGA, 64KB Flash Memory, 4 + 2KB SRAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5524.pdf
 $ENDCMP
 #
 $CMP MSP430F5526IYFF
 D 64ball BGA, 96KB Flash Memory, 6 + 2KB SRAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5524.pdf
 $ENDCMP
 #
 $CMP MSP430F5528IYFF
 D 64ball BGA, 128KB Flash Memory, 8 + 2KB SRAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5524.pdf
 $ENDCMP
 #
 $CMP MSP430F5630IZQW
 D 113ball BGA, 128KB Flash Memory, 16 + 2KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5630.pdf
 $ENDCMP
 #
 $CMP MSP430F5631IZQW
 D 113ball BGA, 192KB Flash Memory, 16 + 2KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5630.pdf
 $ENDCMP
 #
 $CMP MSP430F5632IZQW
 D 113ball BGA, 256KB Flash Memory, 16 + 2KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5630.pdf
 $ENDCMP
 #
 $CMP MSP430F5633IZQW
 D 113ball BGA, 128KB Flash Memory, 16 + 2KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5630.pdf
 $ENDCMP
 #
 $CMP MSP430F5634IZQW
 D 113ball BGA, 192KB Flash Memory, 16 + 2KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5630.pdf
 $ENDCMP
 #
 $CMP MSP430F5635IZQW
 D 113ball BGA, 256KB Flash Memory, 16 + 2KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5630.pdf
 $ENDCMP
 #
 $CMP MSP430F5636IZQW
 D 113ball BGA, 128KB Flash Memory, 16 + 2KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5630.pdf
 $ENDCMP
 #
 $CMP MSP430F5637IZQW
 D 113ball BGA, 192KB Flash Memory, 16 + 2KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5630.pdf
 $ENDCMP
 #
 $CMP MSP430F5638IZQW
 D 113ball BGA, 256KB Flash Memory, 16 + 2KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5630.pdf
 $ENDCMP
 #
 $CMP MSP430F5658IZQW
 D 113ball BGA, 384KB Flash Memory, 34KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5658.pdf
 $ENDCMP
 #
 $CMP MSP430F5659IZQW
 D 113ball BGA, 512KB Flash Memory, 66KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430f5658.pdf
 $ENDCMP
 #
 $CMP MSP430FR5720IRGE
 D 24pin QFN, 4KB FRAM Memory, 1KB SRAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430fr5720.pdf
 $ENDCMP
 #
 $CMP MSP430FR5722IRGE
 D 24pin QFN, 8KB FRAM Memory, 1KB SRAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430fr5720.pdf
 $ENDCMP
 #
 $CMP MSP430FR5724IRGE
 D 24pin QFN, 8KB FRAM Memory, 1KB SRAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430fr5720.pdf
 $ENDCMP
 #
 $CMP MSP430FR5726IRGE
 D 24pin QFN, 16KB FRAM Memory, 1KB SRAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430fr5720.pdf
 $ENDCMP
 #
 $CMP MSP430FR5728IRGE
 D 24pin QFN, 16KB FRAM Memory, 1KB SRAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430fr5720.pdf
 $ENDCMP
 #
 $CMP MSP430FR5730IRGE
 D 24pin QFN, 4KB FRAM Memory, 1KB SRAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430fr5720.pdf
 $ENDCMP
 #
 $CMP MSP430FR5732IRGE
 D 24pin QFN, 8KB FRAM Memory, 1KB SRAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430fr5720.pdf
 $ENDCMP
 #
 $CMP MSP430FR5734IRGE
 D 24pin QFN, 8KB FRAM Memory, 1KB SRAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430fr5720.pdf
 $ENDCMP
 #
 $CMP MSP430FR5736IRGE
 D 24pin QFN, 16KB FRAM Memory, 1KB SRAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430fr5720.pdf
 $ENDCMP
 #
 $CMP MSP430FR5738IRGE
 D 24pin QFN, 16KB FRAM Memory, 1KB SRAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430fr5720.pdf
 $ENDCMP
 #
 $CMP MSP430G2001IN14
 D 14pin PDIP, 512B Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
 $ENDCMP
 #
 $CMP MSP430G2001IPW14
 D MSP430G2001, 14pin TSSOP, 512B Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
 $ENDCMP
 #
 $CMP MSP430G2001IRSA16
 D MSP430G2001, 16pin QFN, 512B Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
 $ENDCMP
 #
 $CMP MSP430G2101IN14
 D 14pin PDIP, 1KB Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
 $ENDCMP
 #
 $CMP MSP430G2101IPW14
 D MSP430G2101, 14pin TSSOP, 1KB Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
 $ENDCMP
 #
 $CMP MSP430G2101IRSA16
 D MSP430G2101, 16pin QFN, 1KB Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
 $ENDCMP
 #
 $CMP MSP430G2102IN20
 D 20pin PDIP, 1KB Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2102IPW14
 D MSP430G2102, 14pin TSSOP, 1KB Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2102IPW20
 D MSP430G2102, 20pin TSSOP, 1KB Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2102IRSA16
 D MSP430G2102, 16pin QFN, 1KB Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2111IN14
 D 14pin PDIP, 1KB Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
 $ENDCMP
 #
 $CMP MSP430G2111IPW14
 D MSP430G2111, 14pin TSSOP, 1KB Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
 $ENDCMP
 #
 $CMP MSP430G2111IRSA16
 D MSP430G2111, 16pin QFN, 1KB Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
 $ENDCMP
 #
 $CMP MSP430G2112IN20
 D 20pin PDIP, 1KB Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2112IPW14
 D MSP430G2112, 14pin TSSOP, 1KB Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2112IPW20
 D MSP430G2112, 20pin TSSOP, 1KB Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2112IRSA16
 D MSP430G2112, 16pin QFN, 1KB Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2113IPW20
 D MSP430G2113, 20pin TSSOP, 1KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
 $ENDCMP
 #
 $CMP MSP430G2121IN14
 D 14pin PDIP, 1KB Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2121.pdf
 $ENDCMP
 #
 $CMP MSP430G2121IPW14
 D MSP430G2121, 14pin TSSOP, 1KB Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2121.pdf
 $ENDCMP
 #
 $CMP MSP430G2121IRSA16
 D MSP430G2121, 16pin QFN, 1KB Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2121.pdf
 $ENDCMP
 #
 $CMP MSP430G2131IN14
 D MSP430G2121, 14pin PDIP, 1KB Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2121.pdf
 $ENDCMP
 #
 $CMP MSP430G2131IPW14
 D MSP430G2121, 14pin PDIP, 1KB Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2121.pdf
 $ENDCMP
 #
 $CMP MSP430G2131IRSA16
 D MSP430G2131, 16pin QFN, 1KB Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2121.pdf
 $ENDCMP
 #
 $CMP MSP430G2132IN20
 D 20pin PDIP, 1KB Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2132IPW14
 D MSP430G2132, 14pin TSSOP, 1KB Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2132IPW20
 D MSP430G2132, 20pin TSSOP, 1KB Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2132IRSA16
 D MSP430G2132, 16pin QFN, 1KB Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2152IN20
 D 20pin PDIP, 1KB Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2152IPW14
 D MSP430G2152, 14pin TSSOP, 1KB Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2152IPW20
 D MSP430G2152, 20pin TSSOP, 1KB Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2152IRSA16
 D MSP430G2152, 16pin QFN, 1KB Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2152.pdf
 $ENDCMP
 #
 $CMP MSP430G2153IN20
 D MSP430G2113, 20pin PDIP, 1KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
 $ENDCMP
 #
 $CMP MSP430G2153IPW20
 D MSP430G2113, 20pin TSSOP, 1KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
 $ENDCMP
 #
 $CMP MSP430G2153IPW28
 D MSP430G2153, 28pin TQFP, 1KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2153.pdf
 $ENDCMP
 #
 $CMP MSP430G2153IRHB32
 D MSP430G2153, 32pin QFN, 1KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2153.pdf
 $ENDCMP
 #
 $CMP MSP430G2201IN14
 D 14pin PDIP, 2KB Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
 $ENDCMP
 #
 $CMP MSP430G2201IPW14
 D MSP430G2201, 14pin TSSOP, 2KB Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
 $ENDCMP
 #
 $CMP MSP430G2201IRSA16
 D MSP430G2201, 16pin QFN, 2KB Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
 $ENDCMP
 #
 $CMP MSP430G2202IN20
 D 20pin PDIP, 2KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2202IPW14
 D MSP430G2202, 14pin TSSOP, 2KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2202IPW20
 D MSP430G2202, 20pin TSSOP, 2KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2202IRSA16
 D MSP430G2202, 16pin QFN, 2KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2203IN20
 D 20pin PDIP, 2KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2203.pdf
 $ENDCMP
 #
 $CMP MSP430G2203IPW20
 D MSP430G2203, 20pin TSSOP, 2KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2203.pdf
 $ENDCMP
 #
 $CMP MSP430G2203IPW28
 D MSP430G2203, 28pin TSSOP, 2KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2203.pdf
 $ENDCMP
 #
 $CMP MSP430G2203IRHB32
 D MSP430G2203, 32pin QFN, 2KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2203.pdf
 $ENDCMP
 #
 $CMP MSP430G2210ID
 D 8pin PDIP, 2KB + 256B Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2210.pdf
 $ENDCMP
 #
 $CMP MSP430G2211IN14
 D 14pin PDIP, 2KB Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
 $ENDCMP
 #
 $CMP MSP430G2211IPW14
 D MSP430G2211, 14pin TSSOP, 1KB Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
 $ENDCMP
 #
 $CMP MSP430G2211IRSA16
 D MSP430G2211, 16pin QFN, 2KB Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2001.pdf
 $ENDCMP
 #
 $CMP MSP430G2212IN20
 D 20pin PDIP, 2KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2212IPW14
 D MSP430G2212, 14pin TSSOP, 2KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2212IPW20
 D MSP430G2212, 20pin TSSOP, 2KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2212IRSA16
 D MSP430G2212, 16pin QFN, 2KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2213IN20
 D 20pin PDIP, 2KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
 $ENDCMP
 #
 $CMP MSP430G2213IPW20
 D MSP430G2213, 20pin TSSOP, 2KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
 $ENDCMP
 #
 $CMP MSP430G2213IPW28
 D MSP430G2213, 28pin TSSOP, 2KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2213.pdf
 $ENDCMP
 #
 $CMP MSP430G2213IRHB32
 D MSP430G2213, 32pin QFN, 2KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2213.pdf
 $ENDCMP
 #
 $CMP MSP430G2221IN14
 D 14pin PDIP, 2KB Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2121.pdf
 $ENDCMP
 #
 $CMP MSP430G2221IPW14
 D MSP430G2221, 14pin TSSOP, 2KB Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2121.pdf
 $ENDCMP
 #
 $CMP MSP430G2221IRSA16
 D MSP430G2221, 16pin QFN, 2KB Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2121.pdf
 $ENDCMP
 #
 $CMP MSP430G2230ID
 D 8pin SOIC, 2KB + 256B Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2230.pdf
 $ENDCMP
 #
 $CMP MSP430G2231IN14
 D 14pin PDIP, 2KB Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2121.pdf
 $ENDCMP
 #
 $CMP MSP430G2231IPW14
 D MSP430G2231, 14pin PDIP, 2KB Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2121.pdf
 $ENDCMP
 #
 $CMP MSP430G2231IRSA16
 D MSP430G2231, 16pin QFN, 2KB Flash Memory, 128B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2121.pdf
 $ENDCMP
 #
 $CMP MSP430G2232IN20
 D 20pin PDIP, 2KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2232IPW14
 D MSP430G2232, 14pin TSSOP, 2KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2232IPW20
 D MSP430G2232, 20pin TSSOP, 2KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2232IRSA16
 D MSP430G2232, 16pin QFN, 2KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2233IN20
 D 20pin PDIP, 2KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
 $ENDCMP
 #
 $CMP MSP430G2233IPW20
 D MSP430G2233, 20pin TSSOP, 2KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
 $ENDCMP
 #
 $CMP MSP430G2233IPW28
 D MSP430G2233, 28pin TSSOP, 2KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
 $ENDCMP
 #
 $CMP MSP430G2233IRHB32
 D MSP430G2233, 32pin QFN, 2KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
 $ENDCMP
 #
 $CMP MSP430G2252IN20
 D 20pin PDIP, 2KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2252IPW14
 D MSP430G2252, 14pin TSSOP, 2KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2252IPW20
 D MSP430G2252, 20pin TSSOP, 2KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2252IRSA16
 D MSP430G2252, 16pin QFN, 2KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2152.pdf
 $ENDCMP
 #
 $CMP MSP430G2253IN20
 D 20pin PDIP, 2KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
 $ENDCMP
 #
 $CMP MSP430G2253IPW20
 D MSP430G2253, 20pin TSSOP, 2KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
 $ENDCMP
 #
 $CMP MSP430G2253IPW28
 D MSP430G2253, 28pin TQFP, 2KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2153.pdf
 $ENDCMP
 #
 $CMP MSP430G2253IRHB32
 D MSP430G2253, 32pin QFN, 2KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2153.pdf
 $ENDCMP
 #
 $CMP MSP430G2302IN20
 D 20pin PDIP, 4KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2302IPW14
 D MSP430G2302, 14pin TSSOP, 4KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2302IPW20
 D MSP430G2302, 20pin TSSOP, 4KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2302IRSA16
 D MSP430G2302, 16pin QFN, 4KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2303IN20
 D 20pin PDIP, 4KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2203.pdf
 $ENDCMP
 #
 $CMP MSP430G2303IPW20
 D MSP430G2303, 20pin TSSOP, 4KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2203.pdf
 $ENDCMP
 #
 $CMP MSP430G2303IPW28
 D MSP430G2303, 28pin TSSOP, 4KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2203.pdf
 $ENDCMP
 #
 $CMP MSP430G2303IRHB32
 D MSP430G2303, 32pin QFN, 4KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2203.pdf
 $ENDCMP
 #
 $CMP MSP430G2312IN20
 D 20pin PDIP, 4KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2312IPW14
 D MSP430G2312, 14pin TSSOP, 4KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2312IPW20
 D MSP430G2312, 20pin TSSOP, 4KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2312IRSA16
 D MSP430G2312, 16pin QFN, 4KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2313IN20
 D 20pin PDIP, 4KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
 $ENDCMP
 #
 $CMP MSP430G2313IPW20
 D MSP430G2313, 20pin TSSOP, 4KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
 $ENDCMP
 #
 $CMP MSP430G2313IPW28
 D MSP430G2313, 28pin TSSOP, 4KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2213.pdf
 $ENDCMP
 #
 $CMP MSP430G2313IRHB32
 D MSP430G2313, 32pin QFN, 4KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2213.pdf
 $ENDCMP
 #
 $CMP MSP430G2332IN20
 D 20pin PDIP, 4KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2332IPW14
 D MSP430G2332, 14pin TSSOP, 4KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2332IPW20
 D MSP430G2332, 20pin TSSOP, 4KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2332IRSA16
 D MSP430G2332, 16pin QFN, 4KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2333IN20
 D 20pin PDIP, 4KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
 $ENDCMP
 #
 $CMP MSP430G2333IPW20
 D MSP430G2333, 20pin TSSOP, 4KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
 $ENDCMP
 #
 $CMP MSP430G2333IPW28
 D MSP430G2333, 28pin TSSOP, 4KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
 $ENDCMP
 #
 $CMP MSP430G2333IRHB32
 D MSP430G2333, 32pin QFN, 4KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
 $ENDCMP
 #
 $CMP MSP430G2352IN20
 D 20pin PDIP, 4KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2352IPW14
 D MSP430G2352, 14pin TSSOP, 4KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2352IPW20
 D MSP430G2352, 20pin TSSOP, 4KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2352IRSA16
 D MSP430G2352, 16pin QFN, 4KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2152.pdf
 $ENDCMP
 #
 $CMP MSP430G2353IN20
 D 20pin PDIP, 4KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
 $ENDCMP
 #
 $CMP MSP430G2353IPW20
 D MSP430G2353, 20pin TSSOP, 4KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
 $ENDCMP
 #
 $CMP MSP430G2353IPW28
 D MSP430G2353, 28pin TQFP, 4KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2153.pdf
 $ENDCMP
 #
 $CMP MSP430G2353IRHB32
 D MSP430G2353, 32pin QFN, 4KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2153.pdf
 $ENDCMP
 #
 $CMP MSP430G2402IN20
 D 20pin PDIP, 8KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2402IPW14
 D MSP430G2402, 14pin TSSOP, 8KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2402IPW20
 D MSP430G2402, 20pin TSSOP, 8KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2402IRSA16
 D MSP430G2402, 16pin QFN, 8KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2403IN20
 D 20pin PDIP, 8KB Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2203.pdf
 $ENDCMP
 #
 $CMP MSP430G2403IPW20
 D MSP430G2403, 20pin TSSOP, 8KB Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2203.pdf
 $ENDCMP
 #
 $CMP MSP430G2403IPW28
 D MSP430G2403, 28pin TSSOP, 8KB Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2203.pdf
 $ENDCMP
 #
 $CMP MSP430G2403IRHB32
 D MSP430G2403, 32pin QFN, 8KB Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2203.pdf
 $ENDCMP
 #
 $CMP MSP430G2412IN20
 D 20pin PDIP, 8KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2412IPW14
 D MSP430G2412, 14pin TSSOP, 8KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2412IPW20
 D MSP430G2412, 20pin TSSOP, 8KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2412IRSA16
 D MSP430G2412, 16pin QFN, 8KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2413IN20
 D 20pin PDIP, 8KB Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
 $ENDCMP
 #
 $CMP MSP430G2413IPW20
 D MSP430G2413, 20pin TSSOP, 8KB Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
 $ENDCMP
 #
 $CMP MSP430G2413IPW28
 D MSP430G2413, 28pin TSSOP, 8KB Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2213.pdf
 $ENDCMP
 #
 $CMP MSP430G2413IRHB32
 D MSP430G2413, 32pin QFN, 8KB Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2213.pdf
 $ENDCMP
 #
 $CMP MSP430G2432IN20
 D 20pin PDIP, 8KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2432IPW14
 D MSP430G2432, 14pin TSSOP, 8KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2432IPW20
 D MSP430G2432, 20pin TSSOP, 8KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2432IRSA16
 D MSP430G2432, 16pin QFN, 8KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://focus.ti.com/lit/ds/symlink/msp430g2102.pdf
 $ENDCMP
 #
 $CMP MSP430G2433IN20
 D 20pin PDIP, 8KB Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
 $ENDCMP
 #
 $CMP MSP430G2433IPW20
 D MSP430G2433, 20pin TSSOP, 8KB Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
 $ENDCMP
 #
 $CMP MSP430G2433IPW28
 D MSP430G2433, 28pin TSSOP, 8KB Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
 $ENDCMP
 #
 $CMP MSP430G2433IRHB32
 D MSP430G2433, 32pin QFN, 8KB Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
 $ENDCMP
 #
 $CMP MSP430G2444IDA38
 D MSP430G2444, 38pin TSSOP, 8KB + 256B Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2444.pdf
 $ENDCMP
 #
 $CMP MSP430G2444IRHA40
 D MSP430G2444, 40pin QFN, 8KB + 256B Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2444.pdf
 $ENDCMP
 #
 $CMP MSP430G2444IYFF
 D 49ball BGA, 8KB + 256B Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2444.pdf
 $ENDCMP
 #
 $CMP MSP430G2452IN20
 D 20pin PDIP, 8KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2452IPW14
 D MSP430G2452, 14pin TSSOP, 8KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2452IPW20
 D MSP430G2452, 20pin TSSOP, 8KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2112.pdf
 $ENDCMP
 #
 $CMP MSP430G2452IRSA16
 D MSP430G2452, 16pin QFN, 8KB Flash Memory, 256B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2152.pdf
 $ENDCMP
 #
 $CMP MSP430G2453IN20
 D 20pin PDIP, 8KB Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
 $ENDCMP
 #
 $CMP MSP430G2453IPW20
 D MSP430G2453, 20pin TSSOP, 8KB Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
 $ENDCMP
 #
 $CMP MSP430G2453IPW28
 D MSP430G2453, 28pin TQFP, 8KB Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2153.pdf
 $ENDCMP
 #
 $CMP MSP430G2453IRHB32
 D MSP430G2453, 32pin QFN, 8KB Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2153.pdf
 $ENDCMP
 #
 $CMP MSP430G2513IN20
 D 20pin PDIP, 16KB Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
 $ENDCMP
 #
 $CMP MSP430G2513IPW20
 D MSP430G2513, 20pin TSSOP, 16KB Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
 $ENDCMP
 #
 $CMP MSP430G2513IPW28
 D MSP430G2513, 28pin TSSOP, 16KB Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2213.pdf
 $ENDCMP
 #
 $CMP MSP430G2513IRHB32
 D MSP430G2513, 32pin QFN, 16KB Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2213.pdf
 $ENDCMP
 #
 $CMP MSP430G2533IN20
 D 20pin PDIP, 16KB Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
 $ENDCMP
 #
 $CMP MSP430G2533IPW20
 D MSP430G2533, 20pin TSSOP, 16KB Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
 $ENDCMP
 #
 $CMP MSP430G2533IPW28
 D MSP430G2533, 28pin TSSOP, 16KB Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
 $ENDCMP
 #
 $CMP MSP430G2533IRHB32
 D MSP430G2533, 32pin QFN, 16KB Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2233.pdf
 $ENDCMP
 #
 $CMP MSP430G2544IDA38
 D MSP430G2544, 38pin TSSOP, 16KB + 256B Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2444.pdf
 $ENDCMP
 #
 $CMP MSP430G2544IRHA40
 D MSP430G2544, 40pin QFN, 16KB + 256B Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2444.pdf
 $ENDCMP
 #
 $CMP MSP430G2544IYFF
 D 49ball BGA, 16KB + 256B Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2444.pdf
 $ENDCMP
 #
 $CMP MSP430G2553IN20
 D MSP430G2553, 20pin PDIP, 16KB Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
 $ENDCMP
 #
 $CMP MSP430G2553IPW20
 D MSP430G2553, 20pin TSSOP, 16KB Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
 $ENDCMP
 #
 $CMP MSP430G2553IPW28
 D MSP430G2553, 28pin TSSOP, 16KB Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
 $ENDCMP
 #
 $CMP MSP430G2553IRHB32
 D MSP430G2553, 32pin QFN, 16KB Flash Memory, 512B RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2553.pdf
 $ENDCMP
 #
 $CMP MSP430G2744IDA38
 D MSP430G2744, 38pin TSSOP, 32KB + 256B Flash Memory, 1KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2444.pdf
 $ENDCMP
 #
 $CMP MSP430G2744IRHA40
 D MSP430G2744, 40pin QFN, 32KB + 256B Flash Memory, 1KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2444.pdf
 $ENDCMP
 #
 $CMP MSP430G2744IYFF
 D 49ball BGA, 32KB + 256B Flash Memory, 1KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2444.pdf
 $ENDCMP
 #
 $CMP MSP430G2755IDA38
 D MSP430F2755, 38pin TSSOP, 32KB Flash Memory, 4KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2755.pdf
 $ENDCMP
 #
 $CMP MSP430G2755IRHA40
 D MSP430F2755, 40pin QFN, 32KB Flash Memory, 4KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2755.pdf
 $ENDCMP
 #
 $CMP MSP430G2855IDA38
 D MSP430F2855, 38pin TSSOP, 48KB Flash Memory, 4KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2755.pdf
 $ENDCMP
 #
 $CMP MSP430G2855IRHA40
 D MSP430F2855, 40pin QFN, 48KB Flash Memory, 4KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2755.pdf
 $ENDCMP
 #
 $CMP MSP430G2955IDA38
 D MSP430F2955, 38pin TSSOP, 56KB Flash Memory, 4KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2755.pdf
 $ENDCMP
 #
 $CMP MSP430G2955IRHA40
 D MSP430F2955, 40pin QFN, 56KB Flash Memory, 4KB RAM
-K MSP430 MIXED SIGNAL MICROCONTROLLER
+K TI MSP430 16-bit mixed signal microcontroller
 F http://www.ti.com/lit/ds/symlink/msp430g2755.pdf
 $ENDCMP
 #


### PR DESCRIPTION
I started to clean up the MCU_Texas_MSP430 library based on the new KLC3. This PR includes updates of the description, keywords and documentation file for all parts.
Next step would be to rework the LIB file, but that does not seem to be an easy task. A lot of violations to the KLC need to be resolved, and some of the required footprints (e.g., [TVSOP](http://www.ti.com/lit/an/scba009e/scba009e.pdf)) are not available in the .pretty repositories. Any hints how to do this efficiently are welcome. Otherwise I might just update the few parts I am personally interested in.