### PR TITLE
fix two minor bugs in PIC12-lib

### DIFF
--- a/library/MCU_Microchip_PIC12.dcm
+++ b/library/MCU_Microchip_PIC12.dcm
@@ -277,13 +277,7 @@ F http://ww1.microchip.com/downloads/en/devicedoc/40139e.pdf
 $ENDCMP
 #
 $CMP PIC12CE519-ISM
-D 1024W EPROM, 41B SRAM, PDIP8
-K 8-Bit CMOS Microcontroller
-F http://ww1.microchip.com/downloads/en/devicedoc/40139e.pdf
-$ENDCMP
-#
-$CMP PIC12CE519-IMS
-D 1024W EPROM, 41B SRAM, PDIP8
+D 1024W EPROM, 41B SRAM, SO8 Wide
 K 8-Bit CMOS Microcontroller
 F http://ww1.microchip.com/downloads/en/devicedoc/40139e.pdf
 $ENDCMP


### PR DESCRIPTION
- removed non-existent device from DCM (that device really is not produced!)
- fixed one description (package type)